### PR TITLE
add structured logger. Closes #7

### DIFF
--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -3,8 +3,9 @@ package endpoints
 import (
 	"bytes"
 	"encoding/gob"
-	"log"
 	"strings"
+
+	"go.uber.org/zap"
 
 	"github.com/serverless/gateway/db"
 	shortid "github.com/ventu-io/go-shortid"
@@ -14,6 +15,7 @@ import (
 type Endpoints struct {
 	DB      *db.DB
 	Invoker Invoker
+	Logger  *zap.Logger
 }
 
 // Endpoint represents single endpoint
@@ -49,7 +51,7 @@ func (e *Endpoints) GetEndpoint(name string) (*Endpoint, error) {
 	buf := bytes.NewBuffer(value)
 	err = gob.NewDecoder(buf).Decode(fn)
 	if err != nil {
-		log.Printf("fetching endpoint failed: %q", err)
+		e.Logger.Info("fetching endpoint failed", zap.Error(err))
 		return nil, err
 	}
 	return fn, nil

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: f25d7dbc024a0fb7d22005c896377936c15acc854a0195243adc52f59c0cc9f1
-updated: 2017-05-22T10:58:21.465353058+02:00
+hash: 0b03d3db4138fdf1e4427bb6ca2a58e14af0fb34494688358bdf75f7c7c57ad9
+updated: 2017-06-07T12:42:28.504306015+02:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 0b6039ef3d10c1eda49843ebf9773dcc5bba0169
+  version: 512bdaf8bec30abd545b440447cebb57b53d3af9
   subpackages:
   - aws
   - aws/awserr
@@ -20,6 +20,7 @@ imports:
   - aws/request
   - aws/session
   - aws/signer/v4
+  - internal/shareddefaults
   - private/protocol
   - private/protocol/json/jsonutil
   - private/protocol/jsonrpc
@@ -41,6 +42,17 @@ imports:
   version: 8c199fb6259ffc1af525cc3ad52ee60ba8359669
 - name: github.com/ventu-io/go-shortid
   version: 6c56cef5189ca1b3d5ef01dc07f4d611dfc0bb33
+- name: go.uber.org/atomic
+  version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
+- name: go.uber.org/zap
+  version: fab453050a7a08c35f31fc5fff6f2dbd962285ab
+  subpackages:
+  - buffer
+  - internal/bufferpool
+  - internal/color
+  - internal/exit
+  - internal/multierror
+  - zapcore
 - name: golang.org/x/sys
   version: e4594059fe4cde2daf423055a596c2cd1e6c9adf
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,3 +8,7 @@ import:
   version: ^1.8.26
 - package: github.com/ventu-io/go-shortid
   version: ^1.0.0
+- package: go.uber.org/zap
+  version: ^1.4.0
+- package: go.uber.org/atomic
+  version: ^1.2.0


### PR DESCRIPTION
@spacejam by default it produces json. More important is that it's pretty fast and that we can use fields. Logstash can handle json. Same as CloudWatch export to ES feature.

I prefer injecting logger (same as other dependencies). Are you ok with that?