### PR TITLE
no need to double check method case

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -68,7 +68,7 @@ func (router *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rawPath := r.URL.EscapedPath()
 	isAsync := strings.HasSuffix(rawPath, "/async")
 	trimmedPath := strings.TrimSuffix(rawPath, "/async")
-	id := strings.ToUpper(r.Method) + "-" + trimmedPath
+	id := r.Method + "-" + trimmedPath
 	endpointID := endpoints.EndpointID(id)
 	router.log.Debug("router serving request", zap.String("endpoint", string(endpointID)))
 


### PR DESCRIPTION
https://github.com/serverless/event-gateway/blob/master/endpoints/endpoints.go#L23

Method field is validated and only uppercased strings are accepted. Do you think that we need to double check that?