### PR TITLE
Fix a spelling typo

### DIFF
--- a/functions/types.go
+++ b/functions/types.go
@@ -22,7 +22,7 @@ type Caller interface {
 // FunctionID uniquely identifies a function
 type FunctionID string
 
-// Function repesents a deployed on one of the supported providers.
+// Function represents a deployed on one of the supported providers.
 type Function struct {
 	ID       FunctionID `json:"functionId" validate:"required"`
 	Provider *Provider  `json:"provider" validate:"required"`


### PR DESCRIPTION
Fix spelling typo for "represents" in types.go