### PR TITLE
Add Emulator Provider

### DIFF
--- a/functions/functions.go
+++ b/functions/functions.go
@@ -135,11 +135,7 @@ func (f *Functions) validateFunction(fn *Function) error {
 	}
 
 	if fn.Provider.Type == Emulator {
-		if fn.Provider.EmulatorURL == "" {
-			return &ErrValidation{"Missing required field emulatorURL for Emulator function."}
-		} else if fn.Provider.APIVersion == "" {
-			return &ErrValidation{"Missing required field apiVersion for Emulator function."}
-		}
+		return f.validateEmualtor(fn)
 	}
 
 	if fn.Provider.Type == HTTPEndpoint && fn.Provider.URL == "" {
@@ -150,6 +146,15 @@ func (f *Functions) validateFunction(fn *Function) error {
 		return f.validateWeighted(fn)
 	}
 
+	return nil
+}
+
+func (f *Functions) validateEmulator(fn *Function) error {
+	if fn.Provider.EmulatorURL == "" {
+		return &ErrValidation{"Missing required field emulatorURL for Emulator function."}
+	} else if fn.Provider.APIVersion == "" {
+		return &ErrValidation{"Missing required field apiVersion for Emulator function."}
+	}
 	return nil
 }
 

--- a/functions/functions.go
+++ b/functions/functions.go
@@ -135,7 +135,7 @@ func (f *Functions) validateFunction(fn *Function) error {
 	}
 
 	if fn.Provider.Type == Emulator {
-		return f.validateEmualtor(fn)
+		return f.validateEmulator(fn)
 	}
 
 	if fn.Provider.Type == HTTPEndpoint && fn.Provider.URL == "" {

--- a/functions/functions.go
+++ b/functions/functions.go
@@ -134,6 +134,14 @@ func (f *Functions) validateFunction(fn *Function) error {
 		}
 	}
 
+	if fn.Provider.Type == Emulator {
+		if fn.Provider.EmulatorURL == "" {
+			return &ErrValidation{"Missing required field emulatorURL for Emulator function."}
+		} else if fn.Provider.ApiVersion == "" {
+			return &ErrValidation{"Missing required field apiVersion for Emulator function."}
+		}
+	}
+
 	if fn.Provider.Type == HTTPEndpoint && fn.Provider.URL == "" {
 		return &ErrValidation{"Missing required fields for HTTP endpoint."}
 	}

--- a/functions/functions.go
+++ b/functions/functions.go
@@ -137,7 +137,7 @@ func (f *Functions) validateFunction(fn *Function) error {
 	if fn.Provider.Type == Emulator {
 		if fn.Provider.EmulatorURL == "" {
 			return &ErrValidation{"Missing required field emulatorURL for Emulator function."}
-		} else if fn.Provider.ApiVersion == "" {
+		} else if fn.Provider.APIVersion == "" {
 			return &ErrValidation{"Missing required field apiVersion for Emulator function."}
 		}
 	}

--- a/functions/types.go
+++ b/functions/types.go
@@ -68,7 +68,7 @@ type Provider struct {
 
 	// Emulator function
 	EmulatorURL        string `json:"emulatorUrl,omitempty"`
-	ApiVersion         string `json:"apiVersion,omitempty"`
+	APIVersion         string `json:"apiVersion,omitempty"`
 }
 
 // Call tries to send a payload to a target function
@@ -174,30 +174,30 @@ func (f *Function) callEmulator(payload []byte) ([]byte, error) {
 	}
 
 	type EmulatorPayload struct {
-	    FunctionId  string          `json:"functionId"`
-	    Payload     interface{}     `json:"payload"`
+		FunctionID  string          `json:"functionId"`
+		Payload     interface{}     `json:"payload"`
 	}
 
 	var i interface{}
-    err := json.Unmarshal(payload, &i)
+	err := json.Unmarshal(payload, &i)
 
-    emulatorPayload := EmulatorPayload{FunctionId: string(f.ID), Payload: i}
-    buffer := new(bytes.Buffer)
-    json.NewEncoder(buffer).Encode(emulatorPayload)
+	emulatorPayload := EmulatorPayload{FunctionID: string(f.ID), Payload: i}
+	buffer := new(bytes.Buffer)
+	json.NewEncoder(buffer).Encode(emulatorPayload)
 
-	emulatorUrl, err := url.Parse(f.Provider.EmulatorURL)
+	emulatorURL, err := url.Parse(f.Provider.EmulatorURL)
 	if err != nil {
-	    return nil, fmt.Errorf("Invalid Emulator URL %q for Function %q", f.Provider.EmulatorURL, f.ID)
+		return nil, fmt.Errorf("Invalid Emulator URL %q for Function %q", f.Provider.EmulatorURL, f.ID)
 	}
 
-	switch f.Provider.ApiVersion {
-    case "v0":
-        emulatorUrl.Path = path.Join(f.Provider.ApiVersion, "emulator/api/function/invoke")
+	switch f.Provider.APIVersion {
+	case "v0":
+		emulatorURL.Path = path.Join(f.Provider.APIVersion, "emulator/api/function/invoke")
 	default:
-        return []byte{}, fmt.Errorf("Invalid Emulator API version %q for Function %q", f.Provider.ApiVersion, f.ID)
-    }
+		return []byte{}, fmt.Errorf("Invalid Emulator API version %q for Function %q", f.Provider.APIVersion, f.ID)
+	}
 
-	resp, err := client.Post(emulatorUrl.String(), "application/json", buffer)
+	resp, err := client.Post(emulatorURL.String(), "application/json", buffer)
 	if err != nil {
 		return nil, &ErrFunctionCallFailed{err}
 	}


### PR DESCRIPTION
Adds a provider for the [emulator](https://github.com/serverless/emulator).

To add an emulator function:

```json
{
  "functionId": "helloWorld", 
  "provider": {
    "type": "emulator",
    "emulatorUrl": "http://localhost:4000",
    "apiVersion": "v0"
  }
}
```

@mthenw Feel free to change it to your liking 😁 