### PR TITLE
use docker multi-stage build to avoid compile dependencies and reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-FROM golang:1.8-alpine
+FROM golang:1.8-alpine as builder
 
 RUN apk add --update curl git
 RUN curl https://glide.sh/get | sh
 
-WORKDIR $GOPATH/src/github.com/serverless/event-gateway
+WORKDIR /go/src/github.com/serverless/event-gateway
 COPY . .
 
 RUN glide install
 RUN go build -o event-gateway cmd/event-gateway/main.go
 
+FROM alpine:3.6
+WORKDIR /app/
+COPY --from=builder /go/src/github.com/serverless/event-gateway/event-gateway .
 ENTRYPOINT ["./event-gateway"]


### PR DESCRIPTION
At runtime there is no need for the even-gateway image to have `glide` or even `golang` installed. The existing image size amounts to `847MB`.

By using [multi-stage build](https://docs.docker.com/engine/userguide/eng-image/multistage-build/#use-multi-stage-builds) and leverage a minimal alpine base, the final image size is reduced significantly to `35.6MB`
