### PR TITLE
Fix misspelled error message

### DIFF
--- a/subscriptions/errors.go
+++ b/subscriptions/errors.go
@@ -8,7 +8,7 @@ type ErrSubscriptionAlreadyExists struct {
 }
 
 func (e ErrSubscriptionAlreadyExists) Error() string {
-	return fmt.Sprintf("Subscription %q already exits.", e.ID)
+	return fmt.Sprintf("Subscription %q already exists.", e.ID)
 }
 
 // ErrSubscriptionValidation occurs when subscription payload doesn't validate.


### PR DESCRIPTION
Would be a breaking change if someone relies on the error messages (like I do 😬)

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO