### PR TITLE
Update goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 *.swo
 *.db
 default.etcd/
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,3 +7,8 @@ builds:
     goarch:
       - 386
       - amd64
+    hooks:
+      pre: dep ensure
+      post: ./upload.sh
+archive:
+  format: binary

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -18,6 +18,32 @@ cd event-gateway
 docker build -t event-gateway .
 ```
 
+You can also pull pre-built binaries from S3:
+
+```
+$ BUILD=darwin_amd64
+$ wget https://s3.amazonaws.com/eg-binaries/master/${BUILD}/event-gateway
+$ chmod +x event-gateway
+$ ./event-gateway -dev
+```
+
+For `BUILD`, the available choices are:
+
+- darwin_386
+- darwin_amd64
+- linux_386
+- linux_amd64
+- windows_386
+- windows_amd64
+
+To upload new releases to S3, you'll need [`goreleaser`](https://github.com/goreleaser/goreleaser) installed. You also need access keys for the account with the `eg-binaries` bucket.
+
+Run:
+
+```bash
+$ goreleaser --snapshot
+```
+
 ## Running Locally
 
 Run `event-gateway` in `dev` mode:

--- a/upload.sh
+++ b/upload.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+HASH=`git log --pretty=format:'%h' -n 1`
+HASHURL="s3://eg-binaries/${HASH}/"
+MASTERURL="s3://eg-binaries/master/"
+
+echo $HASHURL
+aws s3 cp \
+  dist/ $HASHURL \
+  --acl public-read \
+  --exclude "*.txt" \
+  --exclude "config.yaml" \
+  --recursive
+
+aws s3 sync \
+  $HASHURL $MASTERURL \
+  --acl public-read


### PR DESCRIPTION
## What did you implement:

Easy way to push updated binaries to S3 for distribution.

## How did you implement it:

Updated the `.goreleaser.yaml` config file and added an `upload.sh` script.

Goreleaser will build the various binaries, then the post-hook will upload them to S3. It will upload them in two places: `/<COMMIT-HASH>/<build>/event-gateway` plus `/master/<build>/event-gateway`.

We can run this after merges to master. Then users can download the latest binary at `https://s3.amazonaws.com/eg-binaries/master/${BUILD}/event-gateway`.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES