### PR TITLE
Add a Kinesis provider

### DIFF
--- a/functions/functions.go
+++ b/functions/functions.go
@@ -146,6 +146,12 @@ func (f *Functions) validateFunction(fn *Function) error {
 		return f.validateWeighted(fn)
 	}
 
+	if fn.Provider.Type == AmazonKinesis {
+		if fn.Provider.StreamName == "" || fn.Provider.Region == "" {
+			return &ErrValidation{"Missing required fields for Amazon Kinesis stream."}
+		}
+	}
+
 	return nil
 }
 

--- a/functions/functions.go
+++ b/functions/functions.go
@@ -128,43 +128,48 @@ func (f *Functions) validateFunction(fn *Function) error {
 		return &ErrValidation{err.Error()}
 	}
 
-	if fn.Provider.Type == AWSLambda {
-		if fn.Provider.ARN == "" || fn.Provider.Region == "" {
-			return &ErrValidation{"Missing required fields for AWS Lambda function."}
-		}
-	}
-
-	if fn.Provider.Type == Emulator {
-		return f.validateEmulator(fn)
-	}
-
-	if fn.Provider.Type == HTTPEndpoint && fn.Provider.URL == "" {
-		return &ErrValidation{"Missing required fields for HTTP endpoint."}
-	}
-
-	if fn.Provider.Type == Weighted {
-		return f.validateWeighted(fn)
-	}
-
-	if fn.Provider.Type == AmazonKinesis {
-		if fn.Provider.StreamName == "" || fn.Provider.Region == "" {
-			return &ErrValidation{"Missing required fields for Amazon Kinesis stream."}
-		}
-	}
+    switch fn.Provider.Type {
+    case AWSLambda:
+      return validateAWSLambda(fn)
+    case Emulator:
+      return validateEmulator(fn)
+    case HTTPEndpoint:
+      return validateHTTPEndpoint(fn)
+    case Weighted:
+      return validateWeighted(fn)
+    case AmazonKinesis:
+      return validateAmazonKinesis(fn)
+    }
 
 	return nil
 }
 
-func (f *Functions) validateEmulator(fn *Function) error {
+func validateAWSLambda(fn *Function) error {
+    if fn.Provider.ARN == "" || fn.Provider.Region == "" {
+        return &ErrValidation{"Missing required fields for AWS Lambda function."}
+    }
+
+    return nil
+}
+
+func validateEmulator(fn *Function) error {
 	if fn.Provider.EmulatorURL == "" {
 		return &ErrValidation{"Missing required field emulatorURL for Emulator function."}
 	} else if fn.Provider.APIVersion == "" {
 		return &ErrValidation{"Missing required field apiVersion for Emulator function."}
 	}
+
 	return nil
 }
 
-func (f *Functions) validateWeighted(fn *Function) error {
+func validateHTTPEndpoint(fn *Function) error {
+    if fn.Provider.URL == "" {
+		return &ErrValidation{"Missing required fields for HTTP endpoint."}
+    }
+    return nil
+}
+
+func validateWeighted(fn *Function) error {
 	if len(fn.Provider.Weighted) == 0 {
 		return &ErrValidation{"Missing required fields for weighted function."}
 	}
@@ -179,4 +184,12 @@ func (f *Functions) validateWeighted(fn *Function) error {
 	}
 
 	return nil
+}
+
+func validateAmazonKinesis(fn *Function) error {
+    if fn.Provider.StreamName == "" || fn.Provider.Region == "" {
+        return &ErrValidation{"Missing required fields for Amazon Kinesis stream."}
+    }
+
+    return nil
 }

--- a/router/router.go
+++ b/router/router.go
@@ -384,7 +384,7 @@ func (router *Router) callFunction(backingFunctionID functions.FunctionID, event
 		return nil, err
 	}
 
-	result, err := f.Call(payload)
+	result, err := f.Call(string(event.Type), payload)
 	if err != nil {
 		router.log.Info("Function invocation failed.",
 			zap.String("functionId", string(backingFunctionID)), zap.Object("event", event), zap.Error(err))


### PR DESCRIPTION
## What did you implement:

Closes #189.

Implements a Kinesis provider for routing events to a Kinesis stream.

## How did you implement it:

Two steps:

1. I changed the `Call()` signature of the `Caller` interface to accept an additional `string` parameter which is the `eventType`. This is useful for certain providers, such as a partition key for a Kinesis stream.

2. Added an `AmazonKinesis` provider type and the logic to `callAmazonKinesis`.

## How can we verify it:

1. Create a Kinesis stream in AWS.

2. Create a Kinesis "function" by calling the `/v1/functions` API. Payload body should be:

```
{
    "functionId": "kinesis-stream",
    "provider": {
        "type": "kinesis",
        "region": "<region-of-stream>",
        "awsAccessKeyId": "<access-key-with PutRecord permission>",
        "awsSecretAccessKey": "<secret-access-key>",
        "streamName": "<name-of-stream>"
    }
}
```

3. Create a subscription with the `/v1/subscriptions` API with the following payload:

```
{
	"functionId": "kinesis-stream", 
	"event": "testKinesisEvent"
}
```

4. Invoke your event by calling the Events API with a header of `event: <your-event-name>` and a payload body that you wanted inserted to Kinesis.

5. Check your Kinesis stream to make sure your record made it there. 

💥 

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO