### PR TITLE
flatten header array so it's easier to access headers

### DIFF
--- a/event/http.go
+++ b/event/http.go
@@ -2,7 +2,7 @@ package event
 
 // HTTPEvent is a event schema used for sending events to HTTP subscriptions.
 type HTTPEvent struct {
-	Headers map[string][]string `json:"headers"`
+	Headers map[string]string   `json:"headers"`
 	Query   map[string][]string `json:"query"`
 	Body    interface{}         `json:"body"`
 	Host    string              `json:"host"`

--- a/event/system.go
+++ b/event/system.go
@@ -1,8 +1,6 @@
 package event
 
 import (
-	"net/http"
-
 	"github.com/serverless/event-gateway/function"
 )
 
@@ -11,9 +9,9 @@ const SystemEventReceivedType = Type("gateway.event.received")
 
 // SystemEventReceivedData struct.
 type SystemEventReceivedData struct {
-	Path    string      `json:"path"`
-	Event   Event       `json:"event"`
-	Headers http.Header `json:"header"`
+	Path    string            `json:"path"`
+	Event   Event             `json:"event"`
+	Headers map[string]string `json:"headers"`
 }
 
 // SystemFunctionInvokingType is a system event emitted before invoking a function.


### PR DESCRIPTION
This PR flattens the headers object that it's passed to the functions. Previously it was `map[string][]string` which means that user always had to take the first element of an array. Not it's `map[string]string` so user is able to access header simper e.g. `event.data.headers['Content-Type']`.

In case of multivalue headers they are concatenated with `, ` according to HTTP spec.