### PR TITLE
Minimalize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN go get -u golang.org/x/net/http2
 RUN go get -u golang.org/x/net/trace
 RUN go get -u github.com/golang/dep/cmd/dep
 RUN dep ensure
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o event-gateway cmd/event-gateway/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-w -s' -a -installsuffix cgo -o event-gateway cmd/event-gateway/main.go
 
 FROM scratch
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ WORKDIR /
 COPY --from=builder /go/src/github.com/serverless/event-gateway/event-gateway .
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 EXPOSE 4000 4001
-ENTRYPOINT ["./event-gateway"]
+ENTRYPOINT ["/event-gateway"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN go get -u golang.org/x/net/http2
 RUN go get -u golang.org/x/net/trace
 RUN go get -u github.com/golang/dep/cmd/dep
 RUN dep ensure
-RUN go build -o event-gateway cmd/event-gateway/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o event-gateway cmd/event-gateway/main.go
 
 FROM scratch
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.9-alpine as builder
 RUN apk add --update git
+RUN apk add ca-certificates
 
 WORKDIR /go/src/github.com/serverless/event-gateway
 COPY . .
@@ -13,9 +14,9 @@ RUN go get -u github.com/golang/dep/cmd/dep
 RUN dep ensure
 RUN go build -o event-gateway cmd/event-gateway/main.go
 
-FROM alpine:3.6
-RUN apk add --no-cache ca-certificates
-WORKDIR /app/
+FROM scratch
+WORKDIR /
 COPY --from=builder /go/src/github.com/serverless/event-gateway/event-gateway .
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 EXPOSE 4000 4001
 ENTRYPOINT ["./event-gateway"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o event-gateway cmd
 
 FROM scratch
 WORKDIR /
-COPY --from=builder /go/src/github.com/serverless/event-gateway/event-gateway .
+COPY --from=builder /go/src/github.com/serverless/event-gateway/event-gateway /
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 EXPOSE 4000 4001
 ENTRYPOINT ["/event-gateway"]


### PR DESCRIPTION
The building of the binary should be done on host. Go can build static binaries for any platform, so, why ship the whole build env with the application!