### PR TITLE
add more detailed metrics

### DIFF
--- a/event/system.go
+++ b/event/system.go
@@ -19,6 +19,7 @@ const SystemFunctionInvokingType = Type("gateway.function.invoking")
 
 // SystemFunctionInvokingData struct.
 type SystemFunctionInvokingData struct {
+	Space      string      `json:"space"`
 	FunctionID function.ID `json:"functionId"`
 	Event      Event       `json:"event"`
 }
@@ -28,6 +29,7 @@ const SystemFunctionInvokedType = Type("gateway.function.invoked")
 
 // SystemFunctionInvokedData struct.
 type SystemFunctionInvokedData struct {
+	Space      string      `json:"space"`
 	FunctionID function.ID `json:"functionId"`
 	Event      Event       `json:"event"`
 	Result     []byte      `json:"result"`
@@ -38,7 +40,8 @@ const SystemFunctionInvocationFailedType = Type("gateway.function.invocationFail
 
 // SystemFunctionInvocationFailedData struct.
 type SystemFunctionInvocationFailedData struct {
+	Space      string      `json:"space"`
 	FunctionID function.ID `json:"functionId"`
 	Event      Event       `json:"event"`
-	Error      []byte      `json:"result"`
+	Error      error       `json:"result"`
 }

--- a/httpapi/config.go
+++ b/httpapi/config.go
@@ -46,9 +46,9 @@ func StartConfigAPI(functions function.Service, subscriptions subscription.Servi
 var requestDuration = prometheus.NewHistogram(
 	prometheus.HistogramOpts{
 		Namespace: "gateway",
-		Subsystem: "config",
+		Subsystem: "httpapi",
 		Name:      "request_duration_seconds",
-		Help:      "Bucketed histogram of request duration of config API requests",
+		Help:      "Bucketed histogram of request duration of Config API requests",
 		Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 16),
 	})
 

--- a/httpapi/config.go
+++ b/httpapi/config.go
@@ -46,7 +46,7 @@ func StartConfigAPI(functions function.Service, subscriptions subscription.Servi
 var requestDuration = prometheus.NewHistogram(
 	prometheus.HistogramOpts{
 		Namespace: "gateway",
-		Subsystem: "httpapi",
+		Subsystem: "config",
 		Name:      "request_duration_seconds",
 		Help:      "Bucketed histogram of request duration of Config API requests",
 		Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 16),

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -244,7 +244,7 @@ func (h HTTPAPI) createSubscription(w http.ResponseWriter, r *http.Request, para
 		w.WriteHeader(http.StatusCreated)
 		encoder.Encode(output)
 
-		metricSubscriptionsCreated.WithLabelValues(s.Space).Inc()
+		metricSubscriptionCreated.WithLabelValues(s.Space).Inc()
 	}
 
 	metricSubscriptionCreateRequests.WithLabelValues(s.Space).Inc()
@@ -266,7 +266,7 @@ func (h HTTPAPI) deleteSubscription(w http.ResponseWriter, r *http.Request, para
 	} else {
 		w.WriteHeader(http.StatusNoContent)
 
-		metricSubscriptionsDeleted.WithLabelValues(space).Inc()
+		metricSubscriptionDeleted.WithLabelValues(space).Inc()
 	}
 
 	metricSubscriptionDeleteRequests.WithLabelValues(space).Inc()

--- a/httpapi/metrics.go
+++ b/httpapi/metrics.go
@@ -14,8 +14,8 @@ func init() {
 	prometheus.MustRegister(metricFunctionUpdateRequests)
 	prometheus.MustRegister(metricFunctionListRequests)
 
-	prometheus.MustRegister(metricSubscriptionsCreated)
-	prometheus.MustRegister(metricSubscriptionsDeleted)
+	prometheus.MustRegister(metricSubscriptionCreated)
+	prometheus.MustRegister(metricSubscriptionDeleted)
 
 	prometheus.MustRegister(metricSubscriptionGetRequests)
 	prometheus.MustRegister(metricSubscriptionCreateRequests)
@@ -85,7 +85,7 @@ var metricFunctionListRequests = prometheus.NewCounterVec(
 
 // Subscriptions
 
-var metricSubscriptionsCreated = prometheus.NewCounterVec(
+var metricSubscriptionCreated = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
 		Subsystem: "subscriptions",
@@ -93,7 +93,7 @@ var metricSubscriptionsCreated = prometheus.NewCounterVec(
 		Help:      "Total of subscriptions created.",
 	}, []string{"space"})
 
-var metricSubscriptionsDeleted = prometheus.NewCounterVec(
+var metricSubscriptionDeleted = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
 		Subsystem: "subscriptions",

--- a/httpapi/metrics.go
+++ b/httpapi/metrics.go
@@ -46,7 +46,7 @@ var metricFunctionDeleted = prometheus.NewCounterVec(
 var metricFunctionGetRequests = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
-		Subsystem: "httpapi",
+		Subsystem: "config",
 		Name:      "function_get_requests_total",
 		Help:      "Total of Config API get function requests.",
 	}, []string{"space"})
@@ -54,7 +54,7 @@ var metricFunctionGetRequests = prometheus.NewCounterVec(
 var metricFunctionRegisterRequests = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
-		Subsystem: "httpapi",
+		Subsystem: "config",
 		Name:      "function_register_requests_total",
 		Help:      "Total of Config API register function requests.",
 	}, []string{"space"})
@@ -62,7 +62,7 @@ var metricFunctionRegisterRequests = prometheus.NewCounterVec(
 var metricFunctionDeleteRequests = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
-		Subsystem: "httpapi",
+		Subsystem: "config",
 		Name:      "function_delete_requests_total",
 		Help:      "Total of Config API delete function requests.",
 	}, []string{"space"})
@@ -70,7 +70,7 @@ var metricFunctionDeleteRequests = prometheus.NewCounterVec(
 var metricFunctionUpdateRequests = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
-		Subsystem: "httpapi",
+		Subsystem: "config",
 		Name:      "function_update_requests_total",
 		Help:      "Total of Config API update function requests.",
 	}, []string{"space"})
@@ -78,7 +78,7 @@ var metricFunctionUpdateRequests = prometheus.NewCounterVec(
 var metricFunctionListRequests = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
-		Subsystem: "httpapi",
+		Subsystem: "config",
 		Name:      "function_list_requests_total",
 		Help:      "Total of Config API list functions requests.",
 	}, []string{"space"})
@@ -106,7 +106,7 @@ var metricSubscriptionDeleted = prometheus.NewCounterVec(
 var metricSubscriptionGetRequests = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
-		Subsystem: "httpapi",
+		Subsystem: "config",
 		Name:      "subscription_get_requests_total",
 		Help:      "Total of Config API get subscription requests.",
 	}, []string{"space"})
@@ -114,7 +114,7 @@ var metricSubscriptionGetRequests = prometheus.NewCounterVec(
 var metricSubscriptionCreateRequests = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
-		Subsystem: "httpapi",
+		Subsystem: "config",
 		Name:      "subscription_create_requests_total",
 		Help:      "Total of Config API create subscription requests.",
 	}, []string{"space"})
@@ -122,7 +122,7 @@ var metricSubscriptionCreateRequests = prometheus.NewCounterVec(
 var metricSubscriptionDeleteRequests = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
-		Subsystem: "httpapi",
+		Subsystem: "config",
 		Name:      "subscription_delete_requests_total",
 		Help:      "Total of Config API delete subscription requests.",
 	}, []string{"space"})
@@ -130,7 +130,7 @@ var metricSubscriptionDeleteRequests = prometheus.NewCounterVec(
 var metricSubscriptionListRequests = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
-		Subsystem: "httpapi",
+		Subsystem: "config",
 		Name:      "subscription_list_requests_total",
 		Help:      "Total of Config API list subscriptions requests.",
 	}, []string{"space"})

--- a/httpapi/metrics.go
+++ b/httpapi/metrics.go
@@ -1,0 +1,136 @@
+package httpapi
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func init() {
+	prometheus.MustRegister(metricFunctionRegistered)
+	prometheus.MustRegister(metricFunctionDeleted)
+
+	prometheus.MustRegister(metricFunctionGetRequests)
+	prometheus.MustRegister(metricFunctionRegisterRequests)
+	prometheus.MustRegister(metricFunctionDeleteRequests)
+	prometheus.MustRegister(metricFunctionUpdateRequests)
+	prometheus.MustRegister(metricFunctionListRequests)
+
+	prometheus.MustRegister(metricSubscriptionsCreated)
+	prometheus.MustRegister(metricSubscriptionsDeleted)
+
+	prometheus.MustRegister(metricSubscriptionGetRequests)
+	prometheus.MustRegister(metricSubscriptionCreateRequests)
+	prometheus.MustRegister(metricSubscriptionDeleteRequests)
+	prometheus.MustRegister(metricSubscriptionListRequests)
+}
+
+// Functions
+
+var metricFunctionRegistered = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "gateway",
+		Subsystem: "functions",
+		Name:      "registered_total",
+		Help:      "Total of functions registered.",
+	}, []string{"space"})
+
+var metricFunctionDeleted = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "gateway",
+		Subsystem: "functions",
+		Name:      "deleted_total",
+		Help:      "Total of functions deleted.",
+	}, []string{"space"})
+
+// Functions Config API
+
+var metricFunctionGetRequests = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "gateway",
+		Subsystem: "httpapi",
+		Name:      "function_get_requests_total",
+		Help:      "Total of Config API get function requests.",
+	}, []string{"space"})
+
+var metricFunctionRegisterRequests = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "gateway",
+		Subsystem: "httpapi",
+		Name:      "function_register_requests_total",
+		Help:      "Total of Config API register function requests.",
+	}, []string{"space"})
+
+var metricFunctionDeleteRequests = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "gateway",
+		Subsystem: "httpapi",
+		Name:      "function_delete_requests_total",
+		Help:      "Total of Config API delete function requests.",
+	}, []string{"space"})
+
+var metricFunctionUpdateRequests = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "gateway",
+		Subsystem: "httpapi",
+		Name:      "function_update_requests_total",
+		Help:      "Total of Config API update function requests.",
+	}, []string{"space"})
+
+var metricFunctionListRequests = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "gateway",
+		Subsystem: "httpapi",
+		Name:      "function_list_requests_total",
+		Help:      "Total of Config API list functions requests.",
+	}, []string{"space"})
+
+// Subscriptions
+
+var metricSubscriptionsCreated = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "gateway",
+		Subsystem: "subscriptions",
+		Name:      "created_total",
+		Help:      "Total of subscriptions created.",
+	}, []string{"space"})
+
+var metricSubscriptionsDeleted = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "gateway",
+		Subsystem: "subscriptions",
+		Name:      "deleted_total",
+		Help:      "Total of subscriptions deleted.",
+	}, []string{"space"})
+
+// Subscriptions Config API
+
+var metricSubscriptionGetRequests = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "gateway",
+		Subsystem: "httpapi",
+		Name:      "subscription_get_requests_total",
+		Help:      "Total of Config API get subscription requests.",
+	}, []string{"space"})
+
+var metricSubscriptionCreateRequests = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "gateway",
+		Subsystem: "httpapi",
+		Name:      "subscription_create_requests_total",
+		Help:      "Total of Config API create subscription requests.",
+	}, []string{"space"})
+
+var metricSubscriptionDeleteRequests = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "gateway",
+		Subsystem: "httpapi",
+		Name:      "subscription_delete_requests_total",
+		Help:      "Total of Config API delete subscription requests.",
+	}, []string{"space"})
+
+var metricSubscriptionListRequests = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "gateway",
+		Subsystem: "httpapi",
+		Name:      "subscription_list_requests_total",
+		Help:      "Total of Config API list subscriptions requests.",
+	}, []string{"space"})

--- a/router/metrics.go
+++ b/router/metrics.go
@@ -117,9 +117,9 @@ var metricProcessingDuration = prometheus.NewHistogram(
 	prometheus.HistogramOpts{
 		Namespace: "gateway",
 		Subsystem: "events",
-		Name:      "async_processing_seconds",
+		Name:      "custom_processing_seconds",
 		Help: "Bucketed histogram of processing duration of an event. " +
-			"From receiving the asynchronous event to calling a function.",
+			"From receiving the asynchronous custom event to calling a function.",
 		Buckets: prometheus.ExponentialBuckets(0.00001, 2, 20),
 	})
 

--- a/router/metrics.go
+++ b/router/metrics.go
@@ -17,6 +17,8 @@ func init() {
 	prometheus.MustRegister(metricEventsCustomProcessed)
 	prometheus.MustRegister(metricEventsInvokeReceived)
 	prometheus.MustRegister(metricEventsInvokeProcessed)
+	prometheus.MustRegister(metricEventsHTTPReceived)
+	prometheus.MustRegister(metricEventsHTTPProcessed)
 	prometheus.MustRegister(metricBacklog)
 	prometheus.MustRegister(metricProcessingDuration)
 }

--- a/router/metrics.go
+++ b/router/metrics.go
@@ -69,22 +69,22 @@ var metricEventsAsyncProceeded = prometheus.NewCounter(
 		Help:      "Total of asynchronously proceeded events.",
 	})
 
-var metricEventsInvokeReceived = prometheus.NewCounter(
+var metricEventsInvokeReceived = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
 		Subsystem: "events",
 		Name:      "invoke_received_total",
 		Help:      "Total of Invoke events received.",
-	})
+	}, []string{"space"})
 
-var metricEventsInvokeProceeded = prometheus.NewCounter(
+var metricEventsInvokeProceeded = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
 		Subsystem: "events",
 		Name:      "invoke_proceeded_total",
 		Help: "Total of Invoke events proceeded. This counter excludes events for which there was no function " +
 			"registered or error occured during processing phase.",
-	})
+	}, []string{"space"})
 
 var metricEventsHTTPReceived = prometheus.NewCounter(
 	prometheus.CounterOpts{
@@ -94,14 +94,14 @@ var metricEventsHTTPReceived = prometheus.NewCounter(
 		Help:      "Total of HTTP events received.",
 	})
 
-var metricEventsHTTPProceeded = prometheus.NewCounter(
+var metricEventsHTTPProceeded = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
 		Subsystem: "events",
 		Name:      "http_proceeded_total",
 		Help: "Total of HTTP events proceeded. This counter excludes events for which there was no function " +
 			"registered or error occured during processing phase.",
-	})
+	}, []string{"space"})
 
 var metricBacklog = prometheus.NewGauge(
 	prometheus.GaugeOpts{

--- a/router/metrics.go
+++ b/router/metrics.go
@@ -14,9 +14,9 @@ func init() {
 
 	prometheus.MustRegister(metricEventsAsyncReceived)
 	prometheus.MustRegister(metricEventsAsyncDropped)
-	prometheus.MustRegister(metricEventsAsyncProceeded)
+	prometheus.MustRegister(metricEventsAsyncProcessed)
 	prometheus.MustRegister(metricEventsInvokeReceived)
-	prometheus.MustRegister(metricEventsInvokeProceeded)
+	prometheus.MustRegister(metricEventsInvokeProcessed)
 	prometheus.MustRegister(metricBacklog)
 	prometheus.MustRegister(metricProcessingDuration)
 }
@@ -61,12 +61,12 @@ var metricEventsAsyncDropped = prometheus.NewCounter(
 		Help:      "Total of asynchronously handled events dropped due to insufficient processing power.",
 	})
 
-var metricEventsAsyncProceeded = prometheus.NewCounter(
+var metricEventsAsyncProcessed = prometheus.NewCounter(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
 		Subsystem: "events",
-		Name:      "async_proceeded_total",
-		Help:      "Total of asynchronously proceeded events.",
+		Name:      "async_processed_total",
+		Help:      "Total of asynchronously processed events.",
 	})
 
 var metricEventsInvokeReceived = prometheus.NewCounterVec(
@@ -77,12 +77,12 @@ var metricEventsInvokeReceived = prometheus.NewCounterVec(
 		Help:      "Total of Invoke events received.",
 	}, []string{"space"})
 
-var metricEventsInvokeProceeded = prometheus.NewCounterVec(
+var metricEventsInvokeProcessed = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
 		Subsystem: "events",
-		Name:      "invoke_proceeded_total",
-		Help: "Total of Invoke events proceeded. This counter excludes events for which there was no function " +
+		Name:      "invoke_processed_total",
+		Help: "Total of Invoke events processed. This counter excludes events for which there was no function " +
 			"registered or error occured during processing phase.",
 	}, []string{"space"})
 
@@ -94,12 +94,12 @@ var metricEventsHTTPReceived = prometheus.NewCounter(
 		Help:      "Total of HTTP events received.",
 	})
 
-var metricEventsHTTPProceeded = prometheus.NewCounterVec(
+var metricEventsHTTPProcessed = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
 		Subsystem: "events",
-		Name:      "http_proceeded_total",
-		Help: "Total of HTTP events proceeded. This counter excludes events for which there was no function " +
+		Name:      "http_processed_total",
+		Help: "Total of HTTP events processed. This counter excludes events for which there was no function " +
 			"registered or error occured during processing phase.",
 	}, []string{"space"})
 
@@ -132,9 +132,7 @@ func reportReceivedEvent(id string) {
 	receivedEvents[id] = time.Now()
 }
 
-func reportProceededEvent(id string) {
-	metricEventsAsyncProceeded.Inc()
-
+func reportEventOutOfQueue(id string) {
 	receivedEventsMutex.Lock()
 	defer receivedEventsMutex.Unlock()
 	if startTime, ok := receivedEvents[id]; ok {

--- a/router/metrics.go
+++ b/router/metrics.go
@@ -12,9 +12,9 @@ func init() {
 	prometheus.MustRegister(metricSystemFunctionInvokedReceived)
 	prometheus.MustRegister(metricSystemFunctionInvocationFailedReceived)
 
-	prometheus.MustRegister(metricEventsAsyncReceived)
-	prometheus.MustRegister(metricEventsAsyncDropped)
-	prometheus.MustRegister(metricEventsAsyncProcessed)
+	prometheus.MustRegister(metricEventsCustomReceived)
+	prometheus.MustRegister(metricEventsCustomDropped)
+	prometheus.MustRegister(metricEventsCustomProcessed)
 	prometheus.MustRegister(metricEventsInvokeReceived)
 	prometheus.MustRegister(metricEventsInvokeProcessed)
 	prometheus.MustRegister(metricBacklog)
@@ -45,28 +45,28 @@ var metricSystemFunctionInvocationFailedReceived = prometheus.NewCounterVec(
 		Help:      "Total of gateway.function.invocationFailed events received.",
 	}, []string{"space"})
 
-var metricEventsAsyncReceived = prometheus.NewCounter(
+var metricEventsCustomReceived = prometheus.NewCounter(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
 		Subsystem: "events",
-		Name:      "async_received_total",
-		Help:      "Total of asynchronously handled events received (including system events).",
+		Name:      "custom_received_total",
+		Help:      "Total of asynchronously handled custom events received (including system events).",
 	})
 
-var metricEventsAsyncDropped = prometheus.NewCounter(
+var metricEventsCustomDropped = prometheus.NewCounter(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
 		Subsystem: "events",
-		Name:      "async_dropped_total",
-		Help:      "Total of asynchronously handled events dropped due to insufficient processing power.",
+		Name:      "custom_dropped_total",
+		Help:      "Total of asynchronously handled custom events dropped due to insufficient processing power.",
 	})
 
-var metricEventsAsyncProcessed = prometheus.NewCounter(
+var metricEventsCustomProcessed = prometheus.NewCounter(
 	prometheus.CounterOpts{
 		Namespace: "gateway",
 		Subsystem: "events",
-		Name:      "async_processed_total",
-		Help:      "Total of asynchronously processed events.",
+		Name:      "custom_processed_total",
+		Help:      "Total of asynchronously processed custom events.",
 	})
 
 var metricEventsInvokeReceived = prometheus.NewCounterVec(
@@ -125,7 +125,7 @@ var receivedEventsMutex = sync.Mutex{}
 var receivedEvents = map[string]time.Time{}
 
 func reportReceivedEvent(id string) {
-	metricEventsAsyncReceived.Inc()
+	metricEventsCustomReceived.Inc()
 
 	receivedEventsMutex.Lock()
 	defer receivedEventsMutex.Unlock()

--- a/router/router.go
+++ b/router/router.go
@@ -331,7 +331,7 @@ func (router *Router) enqueueWork(path string, event *eventpkg.Event) {
 		metricBacklog.Inc()
 	default:
 		// We could not submit any work, this is NOT good but we will sacrifice consistency for availability for now.
-		metricEventsAsyncDropped.Inc()
+		metricEventsCustomDropped.Inc()
 	}
 }
 
@@ -446,7 +446,7 @@ func (router *Router) processEvent(e backlogEvent) {
 		router.callFunction(subscriber.Space, subscriber.ID, e.event)
 	}
 
-	metricEventsAsyncProcessed.Inc()
+	metricEventsCustomProcessed.Inc()
 }
 
 func (router *Router) emitSystemEventReceived(path string, event eventpkg.Event, headers map[string]string) error {


### PR DESCRIPTION
This PR adds more detailed metrics, and add support for `space` label for some of them. 

Added metrics (counters):

**Functions/subscriptions** all metrics are labeled with `space` label

* `gateway_functions_registered_total`
* `gateway_functions_deleted_total`
* `gateway_config_function_get_requests_total`
* `gateway_config_function_register_requests_total`
* `gateway_config_function_delete_requests_total`
* `gateway_config_function_update_requests_total`
* `gateway_config_function_list_requests_total`
* `gateway_subscriptions_created_total`
* `gateway_subscriptions_deleted_total`
* `gateway_config_subscription_get_requests_total`
* `gateway_config_subscription_create_requests_total`
* `gateway_config_subscription_delete_requests_total`
* `gateway_config_subscription_list_requests_total`

**Events**:

* `gateway_events_system_function_invoking_received_total` 
* `gateway_events_system_function_invoked_received_total`
* `gateway_events_system_function_invocation_failed_received_total`
* `gateway_events_invoke_received_total`
* `gateway_events_invoke_processed_total`
* `gateway_events_http_received_total`
* `gateway_events_http_processed_total`

All *Events* metrics exept `gateway_events_http_received_total` include `space` label. It's not possible to determine space for HTTP event then it's received.

Regarding events we already have (all without space label) `gateway_events_async_*` metrics which were renamed to

* `gateway_events_custom_received_total`
* `gateway_events_custom_processed_total`
* `gateway_events_custom_dropped_total` 

