### PR TITLE
EG-20 Fix for UpdateFunction

### DIFF
--- a/function/service.go
+++ b/function/service.go
@@ -3,7 +3,7 @@ package function
 // Service represents service for managing functions.
 type Service interface {
 	RegisterFunction(fn *Function) (*Function, error)
-	UpdateFunction(space string, fn *Function) (*Function, error)
+	UpdateFunction(fn *Function) (*Function, error)
 	GetFunction(space string, id ID) (*Function, error)
 	GetFunctions(space string) (Functions, error)
 	DeleteFunction(space string, id ID) error

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -129,9 +129,9 @@ func (h HTTPAPI) updateFunction(w http.ResponseWriter, r *http.Request, params h
 		return
 	}
 
-	space := params.ByName("space")
+	fn.Space = params.ByName("space")
 	fn.ID = function.ID(params.ByName("id"))
-	output, err := h.Functions.UpdateFunction(space, fn)
+	output, err := h.Functions.UpdateFunction(fn)
 	if err != nil {
 		if _, ok := err.(*function.ErrFunctionValidation); ok {
 			w.WriteHeader(http.StatusBadRequest)
@@ -146,7 +146,7 @@ func (h HTTPAPI) updateFunction(w http.ResponseWriter, r *http.Request, params h
 		encoder.Encode(output)
 	}
 
-	metricFunctionUpdateRequests.WithLabelValues(space).Inc()
+	metricFunctionUpdateRequests.WithLabelValues(fn.Space).Inc()
 }
 
 func (h HTTPAPI) deleteFunction(w http.ResponseWriter, r *http.Request, params httprouter.Params) {

--- a/libkv/function.go
+++ b/libkv/function.go
@@ -53,14 +53,14 @@ func (service Service) RegisterFunction(fn *function.Function) (*function.Functi
 }
 
 // UpdateFunction updates function configuration.
-func (service Service) UpdateFunction(space string, fn *function.Function) (*function.Function, error) {
-	_, err := service.FunctionStore.Get(FunctionKey{space, fn.ID}.String(), &store.ReadOptions{Consistent: true})
-	if err != nil {
-		return nil, &function.ErrFunctionNotFound{ID: fn.ID}
+func (service Service) UpdateFunction(fn *function.Function) (*function.Function, error) {
+	if err := service.validateFunction(fn); err != nil {
+		return nil, err
 	}
 
-	if err = service.validateFunction(fn); err != nil {
-		return nil, err
+	_, err := service.FunctionStore.Get(FunctionKey{fn.Space, fn.ID}.String(), &store.ReadOptions{Consistent: true})
+	if err != nil {
+		return nil, &function.ErrFunctionNotFound{ID: fn.ID}
 	}
 
 	byt, err := json.Marshal(fn)

--- a/libkv/function_test.go
+++ b/libkv/function_test.go
@@ -93,7 +93,7 @@ func TestUpdateFunction(t *testing.T) {
 		ID:       "testid",
 		Space:    "default",
 		Provider: &function.Provider{Type: function.HTTPEndpoint, URL: "http://example1.com"}}
-	_, err := service.UpdateFunction("default", fn)
+	_, err := service.UpdateFunction(fn)
 
 	assert.Nil(t, err)
 }
@@ -103,12 +103,10 @@ func TestUpdateFunction_ValidationError(t *testing.T) {
 	defer ctrl.Finish()
 
 	db := mock.NewMockStore(ctrl)
-	returned := []byte(`{"space":"default","functionId":"testid","provider":{"type":"http","url":"http://example.com"}}`)
-	db.EXPECT().Get("default/testid", gomock.Any()).Return(&store.KVPair{Value: returned}, nil)
 	service := &Service{FunctionStore: db, Log: zap.NewNop()}
 
 	fn := &function.Function{ID: "testid", Space: "default", Provider: &function.Provider{Type: function.HTTPEndpoint}}
-	_, err := service.UpdateFunction("default", fn)
+	_, err := service.UpdateFunction(fn)
 
 	assert.Equal(t, err, &function.ErrFunctionValidation{Message: "Missing required fields for HTTP endpoint."})
 }
@@ -125,7 +123,7 @@ func TestUpdateFunction_NotFoundError(t *testing.T) {
 		ID:       "testid",
 		Space:    "default",
 		Provider: &function.Provider{Type: function.HTTPEndpoint, URL: "http://example.com"}}
-	_, err := service.UpdateFunction("default", fn)
+	_, err := service.UpdateFunction(fn)
 
 	assert.Equal(t, err, &function.ErrFunctionNotFound{ID: "testid"})
 }
@@ -147,7 +145,7 @@ func TestUpdateFunction_PutError(t *testing.T) {
 		ID:       "testid",
 		Space:    "default",
 		Provider: &function.Provider{Type: function.HTTPEndpoint, URL: "http://example1.com"}}
-	_, err := service.UpdateFunction("default", fn)
+	_, err := service.UpdateFunction(fn)
 
 	assert.EqualError(t, err, "KV put error")
 }

--- a/mock/function.go
+++ b/mock/function.go
@@ -85,8 +85,8 @@ func (mr *MockFunctionServiceMockRecorder) RegisterFunction(arg0 interface{}) *g
 }
 
 // UpdateFunction mocks base method
-func (m *MockFunctionService) UpdateFunction(arg0 string, arg1 *function.Function) (*function.Function, error) {
-	ret := m.ctrl.Call(m, "UpdateFunction", arg0, arg1)
+func (m *MockFunctionService) UpdateFunction(arg1 *function.Function) (*function.Function, error) {
+	ret := m.ctrl.Call(m, "UpdateFunction", arg1)
 	ret0, _ := ret[0].(*function.Function)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1


### PR DESCRIPTION
## What did you implement:

Calling the `UpdateFunction` endpoint in the ConfigAPI updated the function in the `default` space, even if it was called for a different space. This PR fixes it.

## How did you implement it:

The initial problem is in the [UpdateFunction](https://github.com/serverless/event-gateway/blob/464619f8f98db7afd46fbc1aafb9da24de4dba7f/libkv/function.go#L56) method in `libkv` package. It's passed a `space` and a `*function.Function` instance. The `space` is used correctly when [checking for the function's existence](https://github.com/serverless/event-gateway/blob/464619f8f98db7afd46fbc1aafb9da24de4dba7f/libkv/function.go#L57), but then it uses the `Space` attribute on the `function.Function` instance when [actually updating the function](https://github.com/serverless/event-gateway/blob/464619f8f98db7afd46fbc1aafb9da24de4dba7f/libkv/function.go#L71). The `Space` attribute has been set to `"default"` when it was sent through the `validateFunction` method.

I was going to just change the line to [insert the updated function](https://github.com/serverless/event-gateway/blob/464619f8f98db7afd46fbc1aafb9da24de4dba7f/libkv/function.go#L71) to use the `space` argument, but it seems like the different space confusion (`space` argument vs `fn.Space`) could happen again. Instead, I went up to the `httpapi` package and [set the `fn.Space` there](https://github.com/serverless/event-gateway/blob/UpdateFunctionFix/httpapi/httpapi.go#L132). This is similar to how it's done in the [registerFunction](https://github.com/serverless/event-gateway/blob/UpdateFunctionFix/httpapi/httpapi.go#L97) handler and makes it easier to reason about.

**The only change in behavior is that the function is now validated first, then checked for existence in the key-value store, rather than the other way around.** This is because the `validateFunction` sets the function `Space` if it isn't already set, and I needed to do that before checking for existence in a given space. I don't think the switch of order matters.

The rest of the changes are just around changing the method signature, service interface, and tests for the new `UpdateFunction` method signature.

## How can we verify it:

1. Start the Event Gateway locally: `go run cmd/event-gateway/main.go -dev`

2. Register a function in a space other than "default".

3. Update the function.

4. Call GetFunctions to ensure it reflects your update.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO