### PR TITLE
 hide sensitive information in logs 

### DIFF
--- a/cmd/event-gateway/main.go
+++ b/cmd/event-gateway/main.go
@@ -124,7 +124,7 @@ func main() {
 			configProto = "https"
 		}
 
-		log.Info(fmt.Sprintf("Running in development mode with embedded etcd. Event API listening on %s://localhost:%d. Config API listening on %s://localhost:%d.", eventProto, *eventsPort, configProto, *configPort))
+		log.Info(fmt.Sprintf("Running in development mode with embedded etcd. Events API listening on %s://localhost:%d. Config API listening on %s://localhost:%d.", eventProto, *eventsPort, configProto, *configPort))
 	}
 
 	shutdownGuard.Wait()

--- a/function/function.go
+++ b/function/function.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
+	"go.uber.org/zap/zapcore"
 )
 
 // Function represents a function deployed on one of the supported providers.
@@ -24,6 +25,17 @@ type Function struct {
 	Space    string    `json:"space" validate:"required,min=3,space"`
 	ID       ID        `json:"functionId" validate:"required,functionid"`
 	Provider *Provider `json:"provider" validate:"required"`
+}
+
+// MarshalLogObject is a part of zapcore.ObjectMarshaler interface
+func (f Function) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("space", string(f.Space))
+	enc.AddString("id", string(f.ID))
+	if f.Provider != nil {
+		enc.AddObject("provider", f.Provider)
+	}
+
+	return nil
 }
 
 // Functions is an array of functions.
@@ -56,6 +68,34 @@ type Provider struct {
 
 // ProviderType represents what kind of function provider this is.
 type ProviderType string
+
+// MarshalLogObject is a part of zapcore.ObjectMarshaler interface
+func (p Provider) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("type", string(p.Type))
+	if p.ARN != "" {
+		enc.AddString("arn", p.ARN)
+	}
+	if p.AWSAccessKeyID != "" {
+		enc.AddString("awsAccessKeyId", "*****")
+	}
+	if p.AWSSecretAccessKey != "" {
+		enc.AddString("awsSecretAccessKey", "*****")
+	}
+	if p.AWSSessionToken != "" {
+		enc.AddString("awsSessionToken", "*****")
+	}
+	if p.URL != "" {
+		enc.AddString("url", p.URL)
+	}
+	if p.EmulatorURL != "" {
+		enc.AddString("emulatorUrl", p.EmulatorURL)
+	}
+	if p.APIVersion != "" {
+		enc.AddString("apiVersion", p.APIVersion)
+	}
+
+	return nil
+}
 
 const (
 	// AWSLambda represents AWS Lambda function.

--- a/function/function.go
+++ b/function/function.go
@@ -30,7 +30,7 @@ type Function struct {
 // MarshalLogObject is a part of zapcore.ObjectMarshaler interface
 func (f Function) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("space", string(f.Space))
-	enc.AddString("id", string(f.ID))
+	enc.AddString("functionId", string(f.ID))
 	if f.Provider != nil {
 		enc.AddObject("provider", f.Provider)
 	}

--- a/internal/cache/function_cache.go
+++ b/internal/cache/function_cache.go
@@ -25,18 +25,20 @@ func newFunctionCache(log *zap.Logger) *functionCache {
 }
 
 func (c *functionCache) Modified(k string, v []byte) {
-	c.log.Debug("Function local cache received value update.", zap.String("key", k), zap.String("value", string(v)))
-
 	f := &function.Function{}
 	err := json.NewDecoder(bytes.NewReader(v)).Decode(f)
 	if err != nil {
 		c.log.Error("Could not deserialize Function state.", zap.Error(err), zap.String("key", k), zap.String("value", string(v)))
-	} else {
-		c.Lock()
-		defer c.Unlock()
-		segments := strings.Split(k, "/")
-		c.cache[libkv.FunctionKey{Space: segments[0], ID: function.ID(segments[1])}] = f
+		return
+
 	}
+
+	c.log.Debug("Function local cache received value update.", zap.String("key", k), zap.Object("value", f))
+
+	c.Lock()
+	defer c.Unlock()
+	segments := strings.Split(k, "/")
+	c.cache[libkv.FunctionKey{Space: segments[0], ID: function.ID(segments[1])}] = f
 }
 
 func (c *functionCache) Deleted(k string, v []byte) {

--- a/internal/cache/subscription_cache.go
+++ b/internal/cache/subscription_cache.go
@@ -33,17 +33,17 @@ func newSubscriptionCache(log *zap.Logger) *subscriptionCache {
 }
 
 func (c *subscriptionCache) Modified(k string, v []byte) {
-	c.log.Debug("Subscription local cache received value update.", zap.String("key", k), zap.String("value", string(v)))
-
 	s := subscription.Subscription{}
 	err := json.NewDecoder(bytes.NewReader(v)).Decode(&s)
 	if err != nil {
 		c.log.Error("Could not deserialize Subscription state.", zap.Error(err), zap.String("key", k), zap.String("value", string(v)))
 		return
 	}
+
+	c.log.Debug("Subscription local cache received value update.", zap.String("key", k), zap.Object("value", s))
+
 	c.Lock()
 	defer c.Unlock()
-
 	key := libkv.FunctionKey{Space: s.Space, ID: s.FunctionID}
 
 	if s.Event == eventpkg.TypeHTTP {

--- a/internal/zap/strings.go
+++ b/internal/zap/strings.go
@@ -1,0 +1,14 @@
+package zap
+
+import "go.uber.org/zap/zapcore"
+
+// Strings is a string array that implements MarshalLogArray.
+type Strings []string
+
+// MarshalLogArray implementation
+func (ss Strings) MarshalLogArray(enc zapcore.ArrayEncoder) error {
+	for _, s := range ss {
+		enc.AppendString(s)
+	}
+	return nil
+}

--- a/subscription/subscription.go
+++ b/subscription/subscription.go
@@ -21,7 +21,7 @@ type Subscription struct {
 // MarshalLogObject is a part of zapcore.ObjectMarshaler interface
 func (s Subscription) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("space", string(s.Space))
-	enc.AddString("id", string(s.ID))
+	enc.AddString("subscriptionId", string(s.ID))
 	enc.AddString("event", string(s.Event))
 	enc.AddString("functionId", string(s.FunctionID))
 	if s.Method != "" {

--- a/subscription/subscription.go
+++ b/subscription/subscription.go
@@ -3,6 +3,8 @@ package subscription
 import (
 	"github.com/serverless/event-gateway/event"
 	"github.com/serverless/event-gateway/function"
+	"github.com/serverless/event-gateway/internal/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // Subscription maps event type to a function.
@@ -14,6 +16,25 @@ type Subscription struct {
 	Method     string      `json:"method,omitempty" validate:"omitempty,eq=GET|eq=POST|eq=DELETE|eq=PUT|eq=PATCH|eq=HEAD|eq=OPTIONS"`
 	Path       string      `json:"path,omitempty" validate:"omitempty,urlpath"`
 	CORS       *CORS       `json:"cors,omitempty"`
+}
+
+// MarshalLogObject is a part of zapcore.ObjectMarshaler interface
+func (s Subscription) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("space", string(s.Space))
+	enc.AddString("id", string(s.ID))
+	enc.AddString("event", string(s.Event))
+	enc.AddString("functionId", string(s.FunctionID))
+	if s.Method != "" {
+		enc.AddString("method", string(s.Method))
+	}
+	if s.Path != "" {
+		enc.AddString("path", string(s.Path))
+	}
+	if s.CORS != nil {
+		enc.AddObject("cors", s.CORS)
+	}
+
+	return nil
 }
 
 // Subscriptions is an array of subscriptions.
@@ -28,4 +49,14 @@ type CORS struct {
 	Methods          []string `json:"methods" validate:"min=1"`
 	Headers          []string `json:"headers" validate:"min=1"`
 	AllowCredentials bool     `json:"allowCredentials"`
+}
+
+// MarshalLogObject is a part of zapcore.ObjectMarshaler interface
+func (c CORS) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddArray("origins", zap.Strings(c.Origins))
+	enc.AddArray("methods", zap.Strings(c.Methods))
+	enc.AddArray("headers", zap.Strings(c.Headers))
+	enc.AddBool("allowCredentials", c.AllowCredentials)
+
+	return nil
 }


### PR DESCRIPTION
This PR hides sensitive information (AWS keys) in logs. It's achieved by implementing `MarshalLogObject` function for both Function and Subscription objects. Uber zap then will use it to serialize an object when logging. 