### PR TITLE
Fix minor issue with open api spec

### DIFF
--- a/docs/openapi/openapi-config-api.yaml
+++ b/docs/openapi/openapi-config-api.yaml
@@ -192,6 +192,7 @@ paths:
       operationId: "UpdateSubscription"
       parameters:
       - $ref: "#/components/parameters/Space"
+      - $ref: "#/components/parameters/SubscriptionID"
       requestBody:
         $ref: "#/components/requestBodies/UpdateSubscription"
       responses:


### PR DESCRIPTION
Add SubscriptionID parameter reference to Update Subscription

## What did you implement:

Add SubscriptionID parameter reference to Update Subscription

## How did you implement it:

Trivial change

## How can we verify it:

N/A

## Todos:
N/A

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO