### PR TITLE
Require CloudEvents Source be a URI

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -40,7 +40,7 @@ type Event struct {
 	EventType          Type                   `json:"eventType" validate:"required"`
 	EventTypeVersion   string                 `json:"eventTypeVersion,omitempty"`
 	CloudEventsVersion string                 `json:"cloudEventsVersion" validate:"required"`
-	Source             string                 `json:"source" validate:"url,required"`
+	Source             string                 `json:"source" validate:"uri,required"`
 	EventID            string                 `json:"eventID" validate:"required"`
 	EventTime          time.Time              `json:"eventTime,omitempty"`
 	SchemaURL          string                 `json:"schemaURL,omitempty"`

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -79,7 +79,7 @@ var newTests = []struct {
 		[]byte(`{
 			"eventType": "user.created",
 			"cloudEventsVersion": "`+ eventpkg.TransformationVersion +`",
-			"source": "https://example.com/",
+			"source": "/mysource",
 			"eventID": "6f6ada3b-0aa2-4b3c-989a-91ffc6405f11",
 			"contentType": "text/plain",
 			"data": "test"
@@ -87,7 +87,7 @@ var newTests = []struct {
 		eventpkg.Event{
 			EventType:          eventpkg.Type("user.created"),
 			CloudEventsVersion: eventpkg.TransformationVersion,
-			Source:             "https://example.com/",
+			Source:             "/mysource",
 			ContentType:        "text/plain",
 			Data:               "test",
 		},


### PR DESCRIPTION
## What did you implement:

Changed the validation requirement on the `Source` field of the `Event` struct to require a URI, rather than a URL. This is according to the [CloudEvents spec](https://github.com/cloudevents/spec/blob/master/spec.md#source).

## How did you implement it:

Changed validation on `Source` from `validate:"url,required"` to `validate:"uri,required"`.

I also changed the test that checks that a valid CloudEvent is not transformed into a CloudEvent. I changed the test case's `source` to be a URI rather than a URL so that we would catch this in the future. 

## How can we verify it:

Emit an event in CloudEvents format that uses a URI (not URL) in the `source` property. Make sure that it wasn't transformed into a CloudEvent.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO