### PR TITLE
Use Content-Type application/cloudevents+json for http provider

### DIFF
--- a/providers/http/http.go
+++ b/providers/http/http.go
@@ -32,7 +32,7 @@ func (h HTTP) Call(payload []byte) ([]byte, error) {
 		Timeout: time.Second * 5,
 	}
 
-	resp, err := client.Post(h.URL, "application/json", bytes.NewReader(payload))
+	resp, err := client.Post(h.URL, "application/cloudevents+json", bytes.NewReader(payload))
 	if err != nil {
 		return nil, &function.ErrFunctionCallFailed{Original: err}
 	}

--- a/providers/http/http_test.go
+++ b/providers/http/http_test.go
@@ -22,9 +22,9 @@ func TestLoad(t *testing.T) {
 }
 
 func TestCall(t *testing.T) {
-    var contentType string
+	var contentType string
 	echo := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	    contentType = r.Header.Get("Content-Type")
+		contentType = r.Header.Get("Content-Type")
 		payload, _ := ioutil.ReadAll(r.Body)
 		defer r.Body.Close()
 		fmt.Fprint(w, string(payload))

--- a/providers/http/http_test.go
+++ b/providers/http/http_test.go
@@ -22,7 +22,9 @@ func TestLoad(t *testing.T) {
 }
 
 func TestCall(t *testing.T) {
+    var contentType string
 	echo := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	    contentType = r.Header.Get("Content-Type")
 		payload, _ := ioutil.ReadAll(r.Body)
 		defer r.Body.Close()
 		fmt.Fprint(w, string(payload))
@@ -34,6 +36,7 @@ func TestCall(t *testing.T) {
 	resp, err := provider.Call([]byte("hello"))
 
 	assert.Nil(t, err)
+	assert.Equal(t, "application/cloudevents+json", contentType)
 	assert.Equal(t, "hello", string(resp))
 }
 


### PR DESCRIPTION
## What did you implement:

For the `http` function provider, I changed the `Content-Type` of the outgoing request to `application/cloudevents+json`. This is in accordance with the [CloudEvents spec](https://github.com/cloudevents/spec/blob/master/json-format.md#3-envelope).

## Todos:

- [X] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO