### PR TITLE
Handle +json Content-Type in accordance with RFC6839

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -80,7 +80,7 @@ func New(eventType Type, mime string, payload interface{}) *Event {
 	// which is why we change the event.Data type to "string" for forms, so that, it is left intact.
 	if eventBody, ok := event.Data.([]byte); ok && len(eventBody) > 0 {
 		switch {
-		case mime == mimeJSON:
+		case isJSONContent(mime):
 			json.Unmarshal(eventBody, &event.Data)
 		case strings.HasPrefix(mime, mimeFormMultipart), mime == mimeFormURLEncoded:
 			event.Data = string(eventBody)
@@ -122,7 +122,7 @@ func (e Event) IsSystem() bool {
 }
 
 func parseAsCloudEvent(eventType Type, mime string, payload interface{}) (*Event, error) {
-	if mime != mimeJSON {
+	if !isJSONContent(mime) {
 		return nil, errors.New("content type is not json")
 	}
 	body, ok := payload.([]byte)
@@ -148,4 +148,8 @@ func parseAsCloudEvent(eventType Type, mime string, payload interface{}) (*Event
 	}
 
 	return nil, errors.New("couldn't cast to []byte")
+}
+
+func isJSONContent(mime string) bool {
+    return (mime == mimeJSON || strings.HasSuffix(mime, "+json"))
 }

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -93,6 +93,26 @@ var newTests = []struct {
 		},
 	},
 	{
+		// valid CloudEvent with application/cloudevents+json Content-Type
+		eventpkg.Type("user.created"),
+		"application/cloudevents+json",
+		[]byte(`{
+			"eventType": "user.created",
+			"cloudEventsVersion": "`+ eventpkg.TransformationVersion +`",
+			"source": "/mysource",
+			"eventID": "6f6ada3b-0aa2-4b3c-989a-91ffc6405f11",
+			"contentType": "text/plain",
+			"data": "test"
+			}`),
+		eventpkg.Event{
+			EventType:          eventpkg.Type("user.created"),
+			CloudEventsVersion: eventpkg.TransformationVersion,
+			Source:             "/mysource",
+			ContentType:        "text/plain",
+			Data:               "test",
+		},
+	},
+	{
 		// type mismatch
 		eventpkg.Type("user.deleted"),
 		"application/json",


### PR DESCRIPTION
## What did you implement:

Handles `*+json` Content-Types in accordance with [RFC6839](https://tools.ietf.org/html/rfc6839#section-3.1). This is important for CloudEvents interop, which may be sent in [`application/cloudevents+json`](https://github.com/cloudevents/spec/blob/master/json-format.md#3-envelope) format.

## Todos:

- [X] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO