### PR TITLE
Remove CORS configuration from subscription

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -98,14 +98,6 @@ HTTP subscription response depends on [response object](#respond-to-an-http-requ
 * `404 Not Found` if there is no backing function registered for requested HTTP endpoint
 * `500 Internal Server Error` if the function invocation failed or the backing function didn't return [HTTP response object](#respond-to-an-http-request-event)
 
-##### CORS
-
-By default cross-origin resource sharing (CORS) is disabled for `sync` subscriptions. It can be enabled and configured
-per-subscription basis.
-
-Event Gateway handles preflight `OPTIONS` requests for you. You don't need to setup subscription for `OPTIONS` method
-because the Event Gateway will respond with all appropriate headers.
-
 #### Path parameters
 
 The Event Gateway allows creating HTTP subscription with parameterized paths. Every path segment prefixed with `:` is
@@ -133,11 +125,6 @@ To respond to an HTTP event a function needs to return object with following fie
 * `body` - `string` - required, response body
 
 Currently, the event gateway supports only string responses.
-
-### CORS
-
-Events API supports CORS requests which means that any origin can emit a custom event. In case of `sync` subscriptions CORS is
-configured per-subscription basis.
 
 ## Configuration API
 
@@ -309,11 +296,6 @@ JSON object:
 * `functionId` - `string` - ID of function to receive events
 * `path` - `string` - optional, URL path under which events (HTTP requests) are accepted, default: `/`
 * `method` - `string` - optional, HTTP method that accepts requests, default: `POST`
-* `cors` - `object` - optional, by default CORS is disabled for `sync` subscriptions. When set to empty object CORS configuration will use default values for all fields below. Available fields:
-  * `origins` - `array` of `string` - list of allowed origins. An origin may contain a wildcard (\*) to replace 0 or more characters (i.e.: http://\*.domain.com), default: `*`
-  * `methods` - `array` of `string` - list of allowed methods, default: `HEAD`, `GET`, `POST`
-  * `headers` - `array` of `string` - list of allowed headers, default: `Origin`, `Accept`, `Content-Type`
-  * `allowCredentials` - `bool` - default: false
 
 **Response**
 
@@ -331,7 +313,6 @@ JSON object:
 * `functionId` - function ID
 * `method` - `string` - HTTP method that accepts requests
 * `path` - `string` - path that accepts requests, starts with `/`
-* `cors` - `object` - optional, CORS configuration
 
 ---
 
@@ -350,11 +331,6 @@ _Note that `type`, `eventType`, `functionId`, `path`, and `method` may not be up
 * `functionId` - `string` - ID of function to receive events
 * `path` - `string` - optional, URL path under which events (HTTP requests) are accepted, default: `/`
 * `method` - `string` - optional, HTTP method that accepts requests, default: `POST`
-* `cors` - `object` - optional, by default CORS is disabled for `sync` subscriptions. When set to empty object CORS configuration will use default values for all fields below. Available fields:
-  * `origins` - `array` of `string` - list of allowed origins. An origin may contain a wildcard (\*) to replace 0 or more characters (i.e.: http://\*.domain.com), default: `*`
-  * `methods` - `array` of `string` - list of allowed methods, default: `HEAD`, `GET`, `POST`
-  * `headers` - `array` of `string` - list of allowed headers, default: `Origin`, `Accept`, `Content-Type`
-  * `allowCredentials` - `bool` - default: false
 
 **Response**
 
@@ -373,7 +349,6 @@ JSON object:
 * `functionId` - function ID
 * `method` - `string` - HTTP method that accepts requests
 * `path` - `string` - path that accepts requests, starts with `/`
-* `cors` - `object` - optional, CORS configuration
 
 ---
 
@@ -414,7 +389,6 @@ JSON object:
   * `functionId` - function ID
   * `method` - `string` - HTTP method that accepts requests
   * `path` - `string` - path that accepts requests, starts with `/`
-  * `cors` - `object` - optional, CORS configuration
 
 #### Get Subscription
 
@@ -438,7 +412,6 @@ JSON object:
 * `functionId` - function ID
 * `method` - `string` - HTTP method that accepts requests
 * `path` - `string` - path that accepts requests, starts with `/`
-* `cors` - `object` - optional, CORS configuration
 
 ### Prometheus Metrics
 

--- a/docs/openapi/openapi-config-api.yaml
+++ b/docs/openapi/openapi-config-api.yaml
@@ -290,8 +290,6 @@ components:
           $ref: '#/components/schemas/Path'
         method:
           $ref: '#/components/schemas/Method'
-        cors:
-          $ref: '#/components/schemas/CORS'
     Subscriptions:
       type: object
       properties:
@@ -400,32 +398,6 @@ components:
       properties:
         message:
           type: string
-    CORS:
-      type: object
-      description: "(only for HTTP event) CORS configuration for HTTP event subscription"
-      default: null
-      properties:
-        origins:
-          type: array
-          description: "list of allowed origins. An origin may contain a wildcard (*) to replace 0 or more characters (i.e.: http://*.domain.com)"
-          items:
-            type: string
-          default: ["*"]
-        methods:
-          type: array
-          description: "list of allowed methods"
-          items:
-            type: string
-          default: ["HEAD", "GET", "POST"]
-        headers:
-          type: array
-          description: "list of allowed headers"
-          items:
-            type: string
-          default: ["Origin", "Accept", "Content-Type"]
-        allowCredentials:
-          type: boolean
-          default: false
     Errors:
       type: object
       description: "error response object"
@@ -498,8 +470,6 @@ components:
                 $ref: '#/components/schemas/Path'
               method:
                 $ref: '#/components/schemas/Method'
-              cors:
-                $ref: '#/components/schemas/CORS'
     UpdateSubscription:
       description: "subscription update request body"
       content:
@@ -517,8 +487,6 @@ components:
                 $ref: '#/components/schemas/Path'
               method:
                 $ref: '#/components/schemas/Method'
-              cors:
-                $ref: '#/components/schemas/CORS'
   responses:
     Error:
       description: "internal server error"

--- a/httpapi/httpapi_test.go
+++ b/httpapi/httpapi_test.go
@@ -514,17 +514,9 @@ func TestUpdateSubscription(t *testing.T) {
 		FunctionID: "func",
 		Method:     "GET",
 		Path:       "/",
-		CORS: &subscription.CORS{
-			Origins:          []string{"*"},
-			Methods:          []string{"HEAD", "GET", "POST"},
-			Headers:          []string{"Origin", "Accept", "Content-Type"},
-			AllowCredentials: false,
-		},
 	}
 	updatedValue := []byte(`{"space":"default","subscriptionId":"testid","type":"sync",` +
-		`"eventType":"http.request","functionId":"func","method":"GET","path":"/",` +
-		`"cors":{"origins":["*"],"methods":["HEAD","GET","POST"],` +
-		`"headers":["Origin","Accept","Content-Type"],"allowCredentials":false}}`)
+		`"eventType":"http.request","functionId":"func","method":"GET","path":"/"}`)
 
 	t.Run("subscription updated", func(t *testing.T) {
 		subscriptions.EXPECT().UpdateSubscription(subscription.ID("testid"), updateSub).Return(updateSub, nil)

--- a/internal/cache/subscription_cache.go
+++ b/internal/cache/subscription_cache.go
@@ -49,7 +49,7 @@ func (c *subscriptionCache) Modified(k string, v []byte) {
 			root = pathtree.NewNode()
 			c.endpoints[s.Method] = root
 		}
-		err := root.AddRoute(s.Path, s.Space, s.FunctionID, s.CORS)
+		err := root.AddRoute(s.Path, s.Space, s.FunctionID)
 		if err != nil {
 			c.log.Error("Could not add path to the tree.", zap.Error(err), zap.String("path", s.Path), zap.String("method", s.Method))
 		}

--- a/internal/cache/subscription_cache_test.go
+++ b/internal/cache/subscription_cache_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/serverless/event-gateway/function"
 	"github.com/serverless/event-gateway/libkv"
-	"github.com/serverless/event-gateway/subscription"
 	"github.com/stretchr/testify/assert"
 
 	"go.uber.org/zap"
@@ -59,27 +58,9 @@ func TestSubscriptionCacheModifiedSyncSubscription(t *testing.T) {
 		"path": "/b",
 		"method": "GET"}`))
 
-	space, id, _, _ := scache.endpoints["GET"].Resolve("/a")
+	space, id, _ := scache.endpoints["GET"].Resolve("/a")
 	assert.Equal(t, function.ID("testfunc1"), *id)
 	assert.Equal(t, "default", space)
-}
-
-func TestSubscriptionCacheModifiedCORSConfiguration(t *testing.T) {
-	scache := newSubscriptionCache(zap.NewNop())
-
-	scache.Modified("testsub1", []byte(`{
-		"subscriptionId":"testsub1",
-		"type": "sync",
-		"eventType": "http.request",
-		"functionId": "testfunc1",
-		"path": "/a",
-		"method": "GET",
-		"cors": {
-			"origins": ["http://example.com"]
-		}}`))
-
-	_, _, _, corsConfig := scache.endpoints["GET"].Resolve("/a")
-	assert.Equal(t, &subscription.CORS{Origins: []string{"http://example.com"}}, corsConfig)
 }
 
 func TestSubscriptionCacheModifiedEventsWrongPayload(t *testing.T) {
@@ -139,7 +120,7 @@ func TestSubscriptionCacheModifiedHTTPSubscriptionDeleted(t *testing.T) {
 		"path": "/",
 		"method": "GET"}`))
 
-	space, id, _, _ := scache.endpoints["GET"].Resolve("/")
+	space, id, _ := scache.endpoints["GET"].Resolve("/")
 	assert.Nil(t, id)
 	assert.Equal(t, "", space)
 }

--- a/internal/cache/target.go
+++ b/internal/cache/target.go
@@ -40,7 +40,7 @@ func (tc *Target) SyncSubscriber(method, path string, eventType eventpkg.TypeNam
 		return nil
 	}
 
-	space, functionID, params, cors := root.Resolve(path)
+	space, functionID, params := root.Resolve(path)
 	if functionID == nil {
 		return nil
 	}
@@ -49,7 +49,6 @@ func (tc *Target) SyncSubscriber(method, path string, eventType eventpkg.TypeNam
 		Space:      space,
 		FunctionID: *functionID,
 		Params:     params,
-		CORS:       cors,
 	}
 }
 

--- a/internal/pathtree/tree.go
+++ b/internal/pathtree/tree.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/serverless/event-gateway/function"
-	"github.com/serverless/event-gateway/subscription"
 )
 
 // Node is a data structure, inspired by prefix tree, used for routing HTTP requests in the Event Gateway. It's used for creating tree structure
@@ -16,7 +15,6 @@ type Node struct {
 	children    map[string]*Node
 	space       string
 	functionID  *function.ID
-	cors        *subscription.CORS
 	parameter   string
 	isStatic    bool
 	isParameter bool
@@ -35,11 +33,10 @@ type Params map[string]string
 
 // AddRoute adds route to the tree. This function will panic in case of adding conflicting parameterized paths.
 // nolint: gocyclo
-func (n *Node) AddRoute(route string, space string, functionID function.ID, corsConfig *subscription.CORS) error {
+func (n *Node) AddRoute(route string, space string, functionID function.ID) error {
 	if route == "/" {
 		n.space = space
 		n.functionID = &functionID
-		n.cors = corsConfig
 		return nil
 	}
 
@@ -62,7 +59,6 @@ func (n *Node) AddRoute(route string, space string, functionID function.ID, cors
 				if i == len(segments)-1 {
 					currentNode.children[segment].space = space
 					currentNode.children[segment].functionID = &functionID
-					currentNode.children[segment].cors = corsConfig
 					return nil
 				}
 				currentNode = currentNode.children[segment]
@@ -96,7 +92,6 @@ func (n *Node) AddRoute(route string, space string, functionID function.ID, cors
 			}
 			currentNode.children[segment].space = space
 			currentNode.children[segment].functionID = &functionID
-			currentNode.children[segment].cors = corsConfig
 			return nil
 		}
 		currentNode = currentNode.children[segment]
@@ -110,7 +105,6 @@ func (n *Node) DeleteRoute(route string) error {
 	if route == "/" {
 		n.space = ""
 		n.functionID = nil
-		n.cors = nil
 		return nil
 	}
 
@@ -129,7 +123,6 @@ func (n *Node) DeleteRoute(route string) error {
 			} else {
 				currentNode.children[segment].space = ""
 				currentNode.children[segment].functionID = nil
-				currentNode.children[segment].cors = nil
 			}
 
 			return nil
@@ -143,12 +136,12 @@ func (n *Node) DeleteRoute(route string) error {
 
 // Resolve takes request URL path and traverse the tree trying find corresponding route.
 // nolint: gocyclo
-func (n *Node) Resolve(path string) (string, *function.ID, Params, *subscription.CORS) {
+func (n *Node) Resolve(path string) (string, *function.ID, Params) {
 	if path == "/" {
 		if n.functionID != nil {
-			return n.space, n.functionID, nil, n.cors
+			return n.space, n.functionID, nil
 		}
-		return "", nil, nil, nil
+		return "", nil, nil
 	}
 
 	segments := toSegments(path)
@@ -162,7 +155,7 @@ func (n *Node) Resolve(path string) (string, *function.ID, Params, *subscription
 			// look for param
 			child, exists = first(currentNode.children)
 			if !exists || !(child.isParameter || child.isWildcard) {
-				return "", nil, nil, nil
+				return "", nil, nil
 			}
 		}
 		currentNode = child
@@ -174,15 +167,15 @@ func (n *Node) Resolve(path string) (string, *function.ID, Params, *subscription
 		if currentNode.isWildcard {
 			// add missing parts
 			params[currentNode.parameter] = strings.Join(segments[i:], "/")
-			return currentNode.space, currentNode.functionID, params, currentNode.cors
+			return currentNode.space, currentNode.functionID, params
 		}
 
 		if i == len(segments)-1 {
-			return currentNode.space, currentNode.functionID, params, currentNode.cors
+			return currentNode.space, currentNode.functionID, params
 		}
 	}
 
-	return "", nil, nil, nil
+	return "", nil, nil
 }
 
 func toSegments(route string) []string {

--- a/internal/pathtree/tree_test.go
+++ b/internal/pathtree/tree_test.go
@@ -4,25 +4,23 @@ import (
 	"testing"
 
 	"github.com/serverless/event-gateway/function"
-	"github.com/serverless/event-gateway/subscription"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestResolve_Root(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/", "default", function.ID("testid"), &subscription.CORS{Origins: []string{"http://example.com"}})
+	tree.AddRoute("/", "default", function.ID("testid"))
 
-	space, functionID, _, corsConfig := tree.Resolve("/")
+	space, functionID, _ := tree.Resolve("/")
 
 	assert.Equal(t, function.ID("testid"), *functionID)
 	assert.Equal(t, "default", space)
-	assert.Equal(t, &subscription.CORS{Origins: []string{"http://example.com"}}, corsConfig)
 }
 
 func TestResolve_NoRoot(t *testing.T) {
 	tree := NewNode()
 
-	space, functionID, _, _ := tree.Resolve("/")
+	space, functionID, _ := tree.Resolve("/")
 
 	assert.Nil(t, functionID)
 	assert.Equal(t, "", space)
@@ -30,122 +28,122 @@ func TestResolve_NoRoot(t *testing.T) {
 
 func TestResolve_Static(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/a", "default", function.ID("testid1"), nil)
-	tree.AddRoute("/b", "default", function.ID("testid2"), nil)
-	tree.AddRoute("/a/b", "default", function.ID("testid3"), nil)
-	tree.AddRoute("/d/e/f", "default", function.ID("testid4"), nil)
+	tree.AddRoute("/a", "default", function.ID("testid1"))
+	tree.AddRoute("/b", "default", function.ID("testid2"))
+	tree.AddRoute("/a/b", "default", function.ID("testid3"))
+	tree.AddRoute("/d/e/f", "default", function.ID("testid4"))
 
-	space, functionID, _, _ := tree.Resolve("/a")
+	space, functionID, _ := tree.Resolve("/a")
 	assert.Equal(t, function.ID("testid1"), *functionID)
 	assert.Equal(t, "default", space)
 
-	space, functionID, _, _ = tree.Resolve("/b")
+	space, functionID, _ = tree.Resolve("/b")
 	assert.Equal(t, function.ID("testid2"), *functionID)
 	assert.Equal(t, "default", space)
 
-	space, functionID, _, _ = tree.Resolve("/a/b")
+	space, functionID, _ = tree.Resolve("/a/b")
 	assert.Equal(t, function.ID("testid3"), *functionID)
 	assert.Equal(t, "default", space)
 
-	space, functionID, _, _ = tree.Resolve("/d/e/f")
+	space, functionID, _ = tree.Resolve("/d/e/f")
 	assert.Equal(t, function.ID("testid4"), *functionID)
 	assert.Equal(t, "default", space)
 }
 
 func TestResolve_StaticConflict(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/a", "default", function.ID("testid1"), nil)
+	tree.AddRoute("/a", "default", function.ID("testid1"))
 
-	err := tree.AddRoute("/a", "default", function.ID("testid2"), nil)
+	err := tree.AddRoute("/a", "default", function.ID("testid2"))
 
 	assert.EqualError(t, err, "route /a conflicts with existing route")
 }
 
 func TestResolve_NoPath(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/a/b/c/d", "default", function.ID("testid1"), nil)
+	tree.AddRoute("/a/b/c/d", "default", function.ID("testid1"))
 
-	space, functionID, _, _ := tree.Resolve("/b")
+	space, functionID, _ := tree.Resolve("/b")
 	assert.Nil(t, functionID)
 	assert.Equal(t, "", space)
-	space, functionID, _, _ = tree.Resolve("/a/b")
+	space, functionID, _ = tree.Resolve("/a/b")
 	assert.Nil(t, functionID)
 	assert.Equal(t, "", space)
 }
 
 func TestResolve_TrailingSlash(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/a/", "default", function.ID("testid1"), nil)
+	tree.AddRoute("/a/", "default", function.ID("testid1"))
 
-	_, functionID, _, _ := tree.Resolve("/a")
+	_, functionID, _ := tree.Resolve("/a")
 	assert.Nil(t, functionID)
-	_, functionID, _, _ = tree.Resolve("/a/")
+	_, functionID, _ = tree.Resolve("/a/")
 	assert.Equal(t, function.ID("testid1"), *functionID)
 }
 
 func TestResolve_Param(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/:name", "default", function.ID("testid1"), nil)
-	tree.AddRoute("/:name/:id", "default", function.ID("testid2"), nil)
+	tree.AddRoute("/:name", "default", function.ID("testid1"))
+	tree.AddRoute("/:name/:id", "default", function.ID("testid2"))
 
-	_, functionID, params, _ := tree.Resolve("/foo")
+	_, functionID, params := tree.Resolve("/foo")
 	assert.Equal(t, function.ID("testid1"), *functionID)
 	assert.EqualValues(t, Params{"name": "foo"}, params)
 
-	_, functionID, params, _ = tree.Resolve("/foo/1")
+	_, functionID, params = tree.Resolve("/foo/1")
 	assert.Equal(t, function.ID("testid2"), *functionID)
 	assert.EqualValues(t, Params{"name": "foo", "id": "1"}, params)
 }
 
 func TestResolve_ParamNoMatch(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/:name", "default", function.ID("testid1"), nil)
+	tree.AddRoute("/:name", "default", function.ID("testid1"))
 
-	_, functionID, _, _ := tree.Resolve("/foo/bar/baz")
+	_, functionID, _ := tree.Resolve("/foo/bar/baz")
 	assert.Nil(t, functionID)
 }
 
 func TestResolve_ParamAndStatic(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/:name/bar/:id", "default", function.ID("testid1"), nil)
+	tree.AddRoute("/:name/bar/:id", "default", function.ID("testid1"))
 
-	_, functionID, params, _ := tree.Resolve("/foo/bar/baz")
+	_, functionID, params := tree.Resolve("/foo/bar/baz")
 	assert.Equal(t, function.ID("testid1"), *functionID)
 	assert.EqualValues(t, Params{"name": "foo", "id": "baz"}, params)
 }
 
 func TestResolve_ParamConflict(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/:foo", "default", function.ID("testid1"), nil)
+	tree.AddRoute("/:foo", "default", function.ID("testid1"))
 
-	err := tree.AddRoute("/:bar", "default", function.ID("testid2"), nil)
+	err := tree.AddRoute("/:bar", "default", function.ID("testid2"))
 
 	assert.EqualError(t, err, `parameter with different name ("foo") already defined: for route: /:bar`)
 }
 
 func TestResolve_ParamStaticConflict(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/:foo", "default", function.ID("testid1"), nil)
+	tree.AddRoute("/:foo", "default", function.ID("testid1"))
 
-	err := tree.AddRoute("/bar", "default", function.ID("testid2"), nil)
+	err := tree.AddRoute("/bar", "default", function.ID("testid2"))
 
 	assert.EqualError(t, err, `parameter with different name ("foo") already defined: for route: /bar`)
 }
 
 func TestResolve_StaticParamConflict(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/foo/:bar", "default", function.ID("testid1"), nil)
+	tree.AddRoute("/foo/:bar", "default", function.ID("testid1"))
 
-	err := tree.AddRoute("/:bar", "default", function.ID("testid2"), nil)
+	err := tree.AddRoute("/:bar", "default", function.ID("testid2"))
 
 	assert.EqualError(t, err, "static route already defined for route: /:bar")
 }
 
 func TestResolve_Wildcard(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/*foo", "default", function.ID("testid1"), nil)
+	tree.AddRoute("/*foo", "default", function.ID("testid1"))
 
-	_, functionID, params, _ := tree.Resolve("/foo/bar/baz")
+	_, functionID, params := tree.Resolve("/foo/bar/baz")
 	assert.Equal(t, function.ID("testid1"), *functionID)
 	assert.EqualValues(t, Params{"foo": "foo/bar/baz"}, params)
 }
@@ -153,81 +151,81 @@ func TestResolve_Wildcard(t *testing.T) {
 func TestResolve_WildcardNotLast(t *testing.T) {
 	tree := NewNode()
 
-	err := tree.AddRoute("/*foo/bar", "default", function.ID("testid1"), nil)
+	err := tree.AddRoute("/*foo/bar", "default", function.ID("testid1"))
 
 	assert.EqualError(t, err, "wildcard must be the last parameter")
 }
 
 func TestResolve_WildcardConflict(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/*foo", "default", function.ID("testid1"), nil)
+	tree.AddRoute("/*foo", "default", function.ID("testid1"))
 
-	err := tree.AddRoute("/*bar", "default", function.ID("testid2"), nil)
+	err := tree.AddRoute("/*bar", "default", function.ID("testid2"))
 
 	assert.EqualError(t, err, `wildcard with different name ("foo") already defined: for route: /*bar`)
 }
 
 func TestResolve_WildcardParamConflict(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/*foo", "default", function.ID("testid1"), nil)
+	tree.AddRoute("/*foo", "default", function.ID("testid1"))
 
-	err := tree.AddRoute("/bar", "default", function.ID("testid2"), nil)
+	err := tree.AddRoute("/bar", "default", function.ID("testid2"))
 	assert.EqualError(t, err, `wildcard with different name ("foo") already defined: for route: /bar`)
 
-	err = tree.AddRoute("/:bar", "default", function.ID("testid2"), nil)
+	err = tree.AddRoute("/:bar", "default", function.ID("testid2"))
 	assert.EqualError(t, err, `wildcard with different name ("foo") already defined: for route: /:bar`)
 }
 
 func TestResolve_ParamWildcardConflict(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/:foo", "default", function.ID("testid1"), nil)
+	tree.AddRoute("/:foo", "default", function.ID("testid1"))
 
-	err := tree.AddRoute("/*bar", "default", function.ID("testid2"), nil)
+	err := tree.AddRoute("/*bar", "default", function.ID("testid2"))
 	assert.EqualError(t, err, `wildcard with different name ("foo") already defined: for route: /*bar`)
 }
 
 func TestDeleteRoute_Root(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/", "default", function.ID("testid"), nil)
+	tree.AddRoute("/", "default", function.ID("testid"))
 	tree.DeleteRoute("/")
 
-	_, functionID, _, _ := tree.Resolve("/")
+	_, functionID, _ := tree.Resolve("/")
 
 	assert.Nil(t, functionID)
 }
 
 func TestDeleteRoute_Static(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/a/b/c", "default", function.ID("testid1"), nil)
+	tree.AddRoute("/a/b/c", "default", function.ID("testid1"))
 	tree.DeleteRoute("/a/b/c")
 
-	_, functionID, _, _ := tree.Resolve("/a/b/c")
+	_, functionID, _ := tree.Resolve("/a/b/c")
 
 	assert.Nil(t, functionID)
 }
 
 func TestDeleteRoute_StaticWithChild(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/a", "default", function.ID("testid1"), nil)
-	tree.AddRoute("/a/b", "default", function.ID("testid2"), nil)
+	tree.AddRoute("/a", "default", function.ID("testid1"))
+	tree.AddRoute("/a/b", "default", function.ID("testid2"))
 	tree.DeleteRoute("/a")
 
-	_, functionID, _, _ := tree.Resolve("/a")
+	_, functionID, _ := tree.Resolve("/a")
 	assert.Nil(t, functionID)
-	_, functionID, _, _ = tree.Resolve("/a/b")
+	_, functionID, _ = tree.Resolve("/a/b")
 	assert.Equal(t, function.ID("testid2"), *functionID)
 }
 
 func TestDeleteRoute_ParamWithChild(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/:foo", "default", function.ID("testid1"), nil)
-	tree.AddRoute("/:foo/bar", "default", function.ID("testid2"), nil)
+	tree.AddRoute("/:foo", "default", function.ID("testid1"))
+	tree.AddRoute("/:foo/bar", "default", function.ID("testid2"))
 
 	tree.DeleteRoute("/:foo")
 
-	_, functionID, _, _ := tree.Resolve("/a")
+	_, functionID, _ := tree.Resolve("/a")
 	assert.Nil(t, functionID)
-	_, functionID, _, _ = tree.Resolve("/a/bar")
+	_, functionID, _ = tree.Resolve("/a/bar")
 	assert.Equal(t, function.ID("testid2"), *functionID)
 }
 
@@ -240,10 +238,10 @@ func TestDeleteRoute_NonExisting(t *testing.T) {
 
 func TestDeleteRoute_DeleteParamAddStatic(t *testing.T) {
 	tree := NewNode()
-	tree.AddRoute("/:foo", "default", function.ID("testid1"), nil)
+	tree.AddRoute("/:foo", "default", function.ID("testid1"))
 	tree.DeleteRoute("/:foo")
-	tree.AddRoute("/a", "default", function.ID("testid2"), nil)
+	tree.AddRoute("/a", "default", function.ID("testid2"))
 
-	_, functionID, _, _ := tree.Resolve("/a")
+	_, functionID, _ := tree.Resolve("/a")
 	assert.Equal(t, function.ID("testid2"), *functionID)
 }

--- a/libkv/subscription.go
+++ b/libkv/subscription.go
@@ -172,11 +172,11 @@ func (service Service) checkForPathConflict(space, method, path string) error {
 
 		if sub.Type == subscription.TypeSync {
 			// add existing paths to check
-			tree.AddRoute(sub.Path, sub.Space, function.ID(""), nil)
+			tree.AddRoute(sub.Path, sub.Space, function.ID(""))
 		}
 	}
 
-	err = tree.AddRoute(path, space, function.ID(""), nil)
+	err = tree.AddRoute(path, space, function.ID(""))
 	if err != nil {
 		return &subscription.ErrPathConfict{Message: err.Error()}
 	}
@@ -195,24 +195,6 @@ func validateSubscription(sub *subscription.Subscription) error {
 		sub.Method = http.MethodPost
 	} else {
 		sub.Method = strings.ToUpper(sub.Method)
-	}
-
-	if sub.Type == subscription.TypeAsync && sub.CORS != nil {
-		return &subscription.ErrSubscriptionValidation{Message: "CORS can be configured only for sync subscriptions."}
-	}
-
-	if sub.CORS != nil {
-		if sub.CORS.Headers == nil {
-			sub.CORS.Headers = []string{"Origin", "Accept", "Content-Type"}
-		}
-
-		if sub.CORS.Methods == nil {
-			sub.CORS.Methods = []string{"HEAD", "GET", "POST"}
-		}
-
-		if sub.CORS.Origins == nil {
-			sub.CORS.Origins = []string{"*"}
-		}
 	}
 
 	validate := validator.New()

--- a/libkv/subscription_test.go
+++ b/libkv/subscription_test.go
@@ -87,25 +87,6 @@ func TestCreateSubscription(t *testing.T) {
 				"\nKey: 'Subscription.FunctionID' Error:Field validation for 'FunctionID' failed on the 'required' tag"})
 	})
 
-	t.Run("validation error: CORS settings for async subscription", func(t *testing.T) {
-		subs := &Service{Log: zap.NewNop()}
-
-		_, err := subs.CreateSubscription(
-			&subscription.Subscription{
-				Type:       subscription.TypeAsync,
-				EventType:  "user.created",
-				FunctionID: "func",
-				Path:       "/",
-				Method:     "GET",
-				CORS: &subscription.CORS{
-					Methods: []string{"GET"},
-				},
-			},
-		)
-
-		assert.Equal(t, err, &subscription.ErrSubscriptionValidation{Message: "CORS can be configured only for sync subscriptions."})
-	})
-
 	t.Run("subscription already exists", func(t *testing.T) {
 		subscriptionsDB := mock.NewMockStore(ctrl)
 		subscriptionsDB.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&store.KVPair{Value: []byte(`{"subscriptionId":""}`)}, nil)
@@ -207,9 +188,7 @@ func TestUpdateSubscription(t *testing.T) {
 			syncKey,
 			[]byte(
 				`{"space":"default","subscriptionId":"c3luYyxodHRwLnJlcXVlc3QsZnVuYywlMkYsUE9TVA","type":"sync",`+
-					`"eventType":"http.request","functionId":"func","path":"/","method":"POST",`+
-					`"cors":{"origins":["*"],"methods":["HEAD","GET","POST"],`+
-					`"headers":["Origin","Accept","Content-Type"],"allowCredentials":false}}`),
+					`"eventType":"http.request","functionId":"func","path":"/","method":"POST"}`),
 			nil).Return(nil)
 		functionsDB := mock.NewMockStore(ctrl)
 		functionsDB.EXPECT().Get("default/func", &store.ReadOptions{Consistent: true}).Return(&store.KVPair{Value: funcValue}, nil)
@@ -224,7 +203,7 @@ func TestUpdateSubscription(t *testing.T) {
 				FunctionID: "func",
 				Path:       "/",
 				Method:     "POST",
-				CORS:       &subscription.CORS{Origins: []string{"*"}}})
+			})
 
 		assert.Nil(t, err)
 	})

--- a/router/targeter.go
+++ b/router/targeter.go
@@ -4,7 +4,6 @@ import (
 	"github.com/serverless/event-gateway/event"
 	"github.com/serverless/event-gateway/function"
 	"github.com/serverless/event-gateway/internal/pathtree"
-	"github.com/serverless/event-gateway/subscription"
 )
 
 // Targeter is an interface for retrieving cached configuration for driving performance-sensitive routing decisions.
@@ -21,10 +20,9 @@ type AsyncSubscriber struct {
 	FunctionID function.ID
 }
 
-// SyncSubscriber store info about space, function ID, path params and CORS configuration for sync subscriptions.
+// SyncSubscriber store info about space, function ID and path params for sync subscriptions.
 type SyncSubscriber struct {
 	Space      string
 	FunctionID function.ID
 	Params     pathtree.Params
-	CORS       *subscription.CORS
 }

--- a/subscription/subscription.go
+++ b/subscription/subscription.go
@@ -3,7 +3,6 @@ package subscription
 import (
 	"github.com/serverless/event-gateway/event"
 	"github.com/serverless/event-gateway/function"
-	"github.com/serverless/event-gateway/internal/zap"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -16,7 +15,6 @@ type Subscription struct {
 	FunctionID function.ID    `json:"functionId" validate:"required"`
 	Path       string         `json:"path" validate:"required,urlPath"`
 	Method     string         `json:"method" validate:"required,eq=GET|eq=POST|eq=DELETE|eq=PUT|eq=PATCH|eq=HEAD|eq=OPTIONS"`
-	CORS       *CORS          `json:"cors,omitempty"`
 }
 
 // ID uniquely identifies a subscription.
@@ -48,27 +46,6 @@ func (s Subscription) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	if s.Path != "" {
 		enc.AddString("path", string(s.Path))
 	}
-	if s.CORS != nil {
-		enc.AddObject("cors", s.CORS)
-	}
-
-	return nil
-}
-
-// CORS is used to configure CORS on HTTP subscriptions.
-type CORS struct {
-	Origins          []string `json:"origins" validate:"min=1"`
-	Methods          []string `json:"methods" validate:"min=1"`
-	Headers          []string `json:"headers" validate:"min=1"`
-	AllowCredentials bool     `json:"allowCredentials"`
-}
-
-// MarshalLogObject is a part of zapcore.ObjectMarshaler interface
-func (c CORS) MarshalLogObject(enc zapcore.ObjectEncoder) error {
-	enc.AddArray("origins", zap.Strings(c.Origins))
-	enc.AddArray("methods", zap.Strings(c.Methods))
-	enc.AddArray("headers", zap.Strings(c.Headers))
-	enc.AddBool("allowCredentials", c.AllowCredentials)
 
 	return nil
 }


### PR DESCRIPTION
## What did you implement:

Part of https://github.com/serverless/event-gateway/issues/438

## How did you implement it:

It removes the remainings of CORS configuration in subscription model. 

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES