### PR TITLE
Fix payload normalization in http.request events. Closes #434

### DIFF
--- a/event/event_test.go
+++ b/event/event_test.go
@@ -268,22 +268,24 @@ var fromRequestTests = []struct {
 		},
 	},
 	{
-		name: "regular HTTP request",
+		name: "regular HTTP JSON request",
 		requestHeaders: http.Header{
 			"Content-Type": []string{"application/json"},
 		},
-		requestBody: []byte("hey there"),
+		requestBody: []byte(`{"key": "value"}`),
 		expectedEvent: &eventpkg.Event{
 			EventType:          eventpkg.TypeHTTPRequest,
 			CloudEventsVersion: "0.1",
 			Source:             "https://serverless.com/event-gateway/#transformationVersion=0.1",
-			ContentType:        "application/cloudevents+json",
+			ContentType:        "application/json",
 			Data: &eventpkg.HTTPRequestData{
 				Headers: map[string]string{
 					"Content-Type": "application/json",
 				},
 				Query: map[string][]string{},
-				Body:  []byte("hey there"),
+				Body: map[string]interface{}{
+					"key": "value",
+				},
 			},
 			Extensions: map[string]interface{}{
 				"eventgateway": map[string]interface{}{"transformed": "true", "transformation-version": "0.1"}},

--- a/event/http.go
+++ b/event/http.go
@@ -19,7 +19,7 @@ type HTTPRequestData struct {
 
 // NewHTTPRequestData returns a new instance of HTTPRequestData
 func NewHTTPRequestData(r *http.Request, eventData interface{}) *HTTPRequestData {
-	return &HTTPRequestData{
+	req := &HTTPRequestData{
 		Headers: ihttp.FlattenHeader(r.Header),
 		Query:   r.URL.Query(),
 		Body:    eventData,
@@ -27,4 +27,7 @@ func NewHTTPRequestData(r *http.Request, eventData interface{}) *HTTPRequestData
 		Path:    r.URL.Path,
 		Method:  r.Method,
 	}
+
+	req.Body = normalizePayload(req.Body, r.Header.Get("content-type"))
+	return req
 }


### PR DESCRIPTION
## What did you implement:

Closes #434

## How did you implement it:

When we moved from HTTP event to http.request event as CloudEvent the normalization need to happen also for the Body in the event

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO