### PR TITLE
Add 409 return status code to Config API resources (#465)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -141,6 +141,7 @@ Status code:
 
 * `201 Created` on success
 * `400 Bad Request` on validation error
+* `409 Conflict` if event type already exists
 
 JSON object:
 
@@ -285,6 +286,7 @@ Status code:
 
 * `201 Created` on success
 * `400 Bad Request` on validation error
+* `409 Conflict` if function already exists
 
 JSON object:
 
@@ -410,6 +412,7 @@ Status code:
 
 * `201 Created` on success
 * `400 Bad Request` on validation error
+* `409 Conflict` if subscription already exists
 
 JSON object:
 
@@ -545,6 +548,7 @@ Status code:
 
 * `201 Created` on success
 * `400 Bad Request` on validation error
+* `409 Conflict` if CORS configuration already exists
 
 JSON object:
 

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -128,7 +128,7 @@ func (h HTTPAPI) createEventType(w http.ResponseWriter, r *http.Request, params 
 		if _, ok := err.(*event.ErrEventTypeValidation); ok {
 			w.WriteHeader(http.StatusBadRequest)
 		} else if _, ok := err.(*event.ErrEventTypeAlreadyExists); ok {
-			w.WriteHeader(http.StatusBadRequest)
+			w.WriteHeader(http.StatusConflict)
 		} else {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
@@ -263,7 +263,7 @@ func (h HTTPAPI) createFunction(w http.ResponseWriter, r *http.Request, params h
 		if _, ok := err.(*function.ErrFunctionValidation); ok {
 			w.WriteHeader(http.StatusBadRequest)
 		} else if _, ok := err.(*function.ErrFunctionAlreadyRegistered); ok {
-			w.WriteHeader(http.StatusBadRequest)
+			w.WriteHeader(http.StatusConflict)
 		} else {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
@@ -393,7 +393,7 @@ func (h HTTPAPI) createSubscription(w http.ResponseWriter, r *http.Request, para
 	output, err := h.Subscriptions.CreateSubscription(s)
 	if err != nil {
 		if _, ok := err.(*subscription.ErrSubscriptionAlreadyExists); ok {
-			w.WriteHeader(http.StatusBadRequest)
+			w.WriteHeader(http.StatusConflict)
 		} else if _, ok := err.(*event.ErrEventTypeNotFound); ok {
 			w.WriteHeader(http.StatusBadRequest)
 		} else if _, ok := err.(*function.ErrFunctionNotFound); ok {
@@ -534,7 +534,7 @@ func (h HTTPAPI) createCORS(w http.ResponseWriter, r *http.Request, params httpr
 	output, err := h.CORSes.CreateCORS(config)
 	if err != nil {
 		if _, ok := err.(*cors.ErrCORSAlreadyExists); ok {
-			w.WriteHeader(http.StatusBadRequest)
+			w.WriteHeader(http.StatusConflict)
 		} else if _, ok := err.(*cors.ErrCORSValidation); ok {
 			w.WriteHeader(http.StatusBadRequest)
 		} else {

--- a/httpapi/httpapi_test.go
+++ b/httpapi/httpapi_test.go
@@ -541,6 +541,120 @@ func TestListSubscriptions(t *testing.T) {
 	})
 }
 
+func TestCreateSubscription(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	router, _, _, subscriptions, _ := setup(ctrl)
+	subPayload := []byte(`{"type":"sync","eventType":"http.request",` +
+		`"functionId":"func","method":"GET","path":"/"}`)
+
+	createSub := &subscription.Subscription{
+		Space:      "default",
+		Type:       subscription.TypeSync,
+		EventType:  "http.request",
+		FunctionID: "func",
+		Method:     "GET",
+		Path:       "/",
+	}
+
+	t.Run("subscription created", func(t *testing.T) {
+		subscriptions.EXPECT().CreateSubscription(createSub).Return(createSub, nil)
+		resp := request(router, http.MethodPost, "/v1/spaces/default/subscriptions", subPayload)
+
+		sub := &subscription.Subscription{}
+		json.Unmarshal(resp.Body.Bytes(), sub)
+		assert.Equal(t, http.StatusCreated, resp.Code)
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
+		assert.Equal(t, "default", sub.Space)
+		assert.Equal(t, function.ID("func"), sub.FunctionID)
+		assert.Equal(t, event.TypeName("http.request"), sub.EventType)
+		assert.Equal(t, subscription.TypeSync, sub.Type)
+		assert.Equal(t, "/", sub.Path)
+		assert.Equal(t, "GET", sub.Method)
+		assert.NotNil(t, sub.ID)
+	})
+
+	t.Run("subscription already exists", func(t *testing.T) {
+		subscriptions.EXPECT().CreateSubscription(gomock.Any()).
+			Return(nil, &subscription.ErrSubscriptionAlreadyExists{ID: subscription.ID("sub1")})
+
+		resp := request(router, http.MethodPost, "/v1/spaces/default/subscriptions", subPayload)
+
+		httpresp := &httpapi.Response{}
+		json.Unmarshal(resp.Body.Bytes(), httpresp)
+		assert.Equal(t, http.StatusConflict, resp.Code)
+		assert.Equal(t, `Subscription "sub1" already exists.`, httpresp.Errors[0].Message)
+	})
+
+	t.Run("subscription validation error", func(t *testing.T) {
+		subscriptions.EXPECT().CreateSubscription(gomock.Any()).
+			Return(nil, &subscription.ErrSubscriptionValidation{Message: "wrong function ID format"})
+
+		resp := request(router, http.MethodPost, "/v1/spaces/default/subscriptions", subPayload)
+
+		httpresp := &httpapi.Response{}
+		json.Unmarshal(resp.Body.Bytes(), httpresp)
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, `Subscription doesn't validate. Validation error: wrong function ID format`, httpresp.Errors[0].Message)
+	})
+
+	t.Run("function not found", func(t *testing.T) {
+		subscriptions.EXPECT().CreateSubscription(gomock.Any()).
+			Return(nil, &function.ErrFunctionNotFound{ID: function.ID("func")})
+
+		resp := request(router, http.MethodPost, "/v1/spaces/default/subscriptions", subPayload)
+
+		httpresp := &httpapi.Response{}
+		json.Unmarshal(resp.Body.Bytes(), httpresp)
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, `Function "func" not found.`, httpresp.Errors[0].Message)
+	})
+
+	t.Run("event type not found", func(t *testing.T) {
+		subscriptions.EXPECT().CreateSubscription(gomock.Any()).
+			Return(nil, &event.ErrEventTypeNotFound{Name: event.TypeName("http.request")})
+
+		resp := request(router, http.MethodPost, "/v1/spaces/default/subscriptions", subPayload)
+
+		httpresp := &httpapi.Response{}
+		json.Unmarshal(resp.Body.Bytes(), httpresp)
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, `Event Type "http.request" not found.`, httpresp.Errors[0].Message)
+	})
+
+	t.Run("path conflict", func(t *testing.T) {
+		subscriptions.EXPECT().CreateSubscription(gomock.Any()).
+			Return(nil, &subscription.ErrPathConfict{Message: "route / conflicts with existing route"})
+
+		resp := request(router, http.MethodPost, "/v1/spaces/default/subscriptions", subPayload)
+
+		httpresp := &httpapi.Response{}
+		json.Unmarshal(resp.Body.Bytes(), httpresp)
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, `Subscription path conflict: route / conflicts with existing route`, httpresp.Errors[0].Message)
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		resp := request(router, http.MethodPost, "/v1/spaces/default/subscriptions", []byte(`{"name":"te`))
+
+		httpresp := &httpapi.Response{}
+		json.Unmarshal(resp.Body.Bytes(), httpresp)
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, "Subscription doesn't validate. Validation error: unexpected EOF", httpresp.Errors[0].Message)
+	})
+
+	t.Run("internal error", func(t *testing.T) {
+		subscriptions.EXPECT().CreateSubscription(gomock.Any()).Return(nil, errors.New("processing failed"))
+
+		resp := request(router, http.MethodPost, "/v1/spaces/default/subscriptions", subPayload)
+
+		httpresp := &httpapi.Response{}
+		json.Unmarshal(resp.Body.Bytes(), httpresp)
+		assert.Equal(t, http.StatusInternalServerError, resp.Code)
+		assert.Equal(t, "processing failed", httpresp.Errors[0].Message)
+	})
+}
+
 func TestUpdateSubscription(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/httpapi/httpapi_test.go
+++ b/httpapi/httpapi_test.go
@@ -128,7 +128,7 @@ func TestCreateEventType(t *testing.T) {
 
 		httpresp := &httpapi.Response{}
 		json.Unmarshal(resp.Body.Bytes(), httpresp)
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusConflict, resp.Code)
 		assert.Equal(t, `Event Type "test.event" already exists.`, httpresp.Errors[0].Message)
 	})
 
@@ -415,7 +415,7 @@ func TestRegisterFunction(t *testing.T) {
 
 		httpresp := &httpapi.Response{}
 		json.Unmarshal(resp.Body.Bytes(), httpresp)
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusConflict, resp.Code)
 		assert.Equal(t, `Function "func1" already registered.`, httpresp.Errors[0].Message)
 	})
 
@@ -762,7 +762,7 @@ func TestCreateCORS(t *testing.T) {
 
 		httpresp := &httpapi.Response{}
 		json.Unmarshal(resp.Body.Bytes(), httpresp)
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusConflict, resp.Code)
 		assert.Equal(t, `CORS configuration "GET%2Fhello" already exists.`, httpresp.Errors[0].Message)
 	})
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/event-gateway/blob/master/CONTRIBUTING.md
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
1. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Modified response status codes from 400 to 409 for POST requests for event types, functions, subscriptions and CORS configs resources. Updated unit tests and API docs accordingly.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.
-->

## Todos:

I'm not sure if a test for `createSubscription` in `httpapi.go` should be added in scope of the task

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO