### PR TITLE
Add support for Metadata field in all resources

### DIFF
--- a/docs/openapi/openapi-config-api.yaml
+++ b/docs/openapi/openapi-config-api.yaml
@@ -37,6 +37,7 @@ paths:
       operationId: "ListEventTypes"
       parameters:
       - $ref: "#/components/parameters/Space"
+      - $ref: "#/components/parameters/Filters"
       responses:
         200:
           description: "event types returned"
@@ -138,6 +139,7 @@ paths:
       operationId: "ListFunctions"
       parameters:
       - $ref: "#/components/parameters/Space"
+      - $ref: "#/components/parameters/Filters"
       responses:
         200:
           description: "functions returned"
@@ -239,6 +241,7 @@ paths:
       operationId: "ListSubscriptions"
       parameters:
       - $ref: "#/components/parameters/Space"
+      - $ref: "#/components/parameters/Filters"
       responses:
         200:
           description: "subscriptions returned"
@@ -338,6 +341,7 @@ paths:
       operationId: "ListCORS"
       parameters:
       - $ref: "#/components/parameters/Space"
+      - $ref: "#/components/parameters/Filters"
       responses:
         200:
           description: "CORS configurations returned"
@@ -704,6 +708,17 @@ components:
       required: true
       schema:
         $ref: "#/components/schemas/CORSID"
+    Filters:
+      in: "query"
+      name: "filters"
+      description: filter out returned list of objects. Currently, filters can only use metadata properties e.g. `metadata.service=usersservice`.
+      style: form
+      example:
+        "metadata.service": usersService
+      schema:
+        type: object
+        additionalProperties:
+          type: string
   requestBodies:
     CreateEventType:
       description: "event type create request body"

--- a/event/service.go
+++ b/event/service.go
@@ -1,9 +1,11 @@
 package event
 
+import "github.com/serverless/event-gateway/metadata"
+
 // Service represents service for managing event types.
 type Service interface {
 	GetEventType(space string, name TypeName) (*Type, error)
-	ListEventTypes(space string) (Types, error)
+	ListEventTypes(space string, filters ...metadata.Filter) (Types, error)
 	CreateEventType(eventType *Type) (*Type, error)
 	UpdateEventType(newEventType *Type) (*Type, error)
 	DeleteEventType(space string, name TypeName) error

--- a/event/type.go
+++ b/event/type.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"github.com/serverless/event-gateway/function"
+	"github.com/serverless/event-gateway/metadata"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -19,7 +20,7 @@ type Type struct {
 	Name         TypeName     `json:"name" validate:"required"`
 	AuthorizerID *function.ID `json:"authorizerId,omitempty"`
 
-	Metadata map[string]string `json:"metadata,omitempty"`
+	Metadata *metadata.Metadata `json:"metadata,omitempty"`
 }
 
 // Types is an array of subscriptions.

--- a/event/type.go
+++ b/event/type.go
@@ -18,6 +18,8 @@ type Type struct {
 	Space        string       `json:"space" validate:"required,min=3,space"`
 	Name         TypeName     `json:"name" validate:"required"`
 	AuthorizerID *function.ID `json:"authorizerId,omitempty"`
+
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 // Types is an array of subscriptions.

--- a/event/type.go
+++ b/event/type.go
@@ -20,7 +20,7 @@ type Type struct {
 	Name         TypeName     `json:"name" validate:"required"`
 	AuthorizerID *function.ID `json:"authorizerId,omitempty"`
 
-	Metadata *metadata.Metadata `json:"metadata,omitempty"`
+	Metadata metadata.Metadata `json:"metadata,omitempty"`
 }
 
 // Types is an array of subscriptions.

--- a/function/function.go
+++ b/function/function.go
@@ -19,7 +19,7 @@ type Function struct {
 	ProviderConfig *json.RawMessage `json:"provider"`
 	Provider       Provider         `json:"-" validate:"-"`
 
-	Metadata *metadata.Metadata `json:"metadata,omitempty"`
+	Metadata metadata.Metadata `json:"metadata,omitempty"`
 }
 
 // Functions is an array of functions.
@@ -56,6 +56,7 @@ func (f *Function) MarshalJSON() ([]byte, error) {
 		ID:             f.ID,
 		ProviderType:   f.ProviderType,
 		ProviderConfig: &rawConfig,
+		Metadata:       f.Metadata,
 	}
 
 	return json.Marshal(fn)
@@ -77,6 +78,7 @@ func (f *Function) UnmarshalJSON(data []byte) error {
 
 	f.ID = rawFunction.ID
 	f.Space = rawFunction.Space
+	f.Metadata = rawFunction.Metadata
 	f.ProviderType = rawFunction.ProviderType
 
 	if loader, ok := providers[rawFunction.ProviderType]; ok {

--- a/function/function.go
+++ b/function/function.go
@@ -17,6 +17,8 @@ type Function struct {
 	ProviderType   ProviderType     `json:"type"`
 	ProviderConfig *json.RawMessage `json:"provider"`
 	Provider       Provider         `json:"-" validate:"-"`
+
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 // Functions is an array of functions.

--- a/function/function.go
+++ b/function/function.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/serverless/event-gateway/metadata"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -18,7 +19,7 @@ type Function struct {
 	ProviderConfig *json.RawMessage `json:"provider"`
 	Provider       Provider         `json:"-" validate:"-"`
 
-	Metadata map[string]string `json:"metadata,omitempty"`
+	Metadata *metadata.Metadata `json:"metadata,omitempty"`
 }
 
 // Functions is an array of functions.

--- a/function/service.go
+++ b/function/service.go
@@ -1,9 +1,11 @@
 package function
 
+import "github.com/serverless/event-gateway/metadata"
+
 // Service represents service for managing functions.
 type Service interface {
 	GetFunction(space string, id ID) (*Function, error)
-	ListFunctions(space string) (Functions, error)
+	ListFunctions(space string, filters ...metadata.Filter) (Functions, error)
 	CreateFunction(fn *Function) (*Function, error)
 	UpdateFunction(fn *Function) (*Function, error)
 	DeleteFunction(space string, id ID) error

--- a/httpapi/httpapi_test.go
+++ b/httpapi/httpapi_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/serverless/event-gateway/event"
 	"github.com/serverless/event-gateway/function"
 	"github.com/serverless/event-gateway/httpapi"
+	"github.com/serverless/event-gateway/metadata"
 	"github.com/serverless/event-gateway/mock"
 	"github.com/serverless/event-gateway/subscription"
 	"github.com/serverless/event-gateway/subscription/cors"
@@ -66,19 +67,19 @@ func TestGetEventType(t *testing.T) {
 	})
 }
 
-func TestGetEventTypes(t *testing.T) {
+func TestListEventTypes(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	router, eventTypes, _, _, _ := setup(ctrl)
 
-	t.Run("event types returned", func(t *testing.T) {
+	t.Run("list returned", func(t *testing.T) {
 		returnedList := event.Types{{
 			Space: "default",
 			Name:  event.TypeName("test.event"),
 		}}
-		eventTypes.EXPECT().ListEventTypes("default").Return(returnedList, nil)
+		eventTypes.EXPECT().ListEventTypes("default", metadata.Filter{Key: "key1", Value: "val1"}).Return(returnedList, nil)
 
-		resp := request(router, http.MethodGet, "/v1/spaces/default/eventtypes", nil)
+		resp := request(router, http.MethodGet, "/v1/spaces/default/eventtypes?metadata.key1=val1", nil)
 
 		types := &httpapi.EventTypesResponse{}
 		json.Unmarshal(resp.Body.Bytes(), types)
@@ -344,21 +345,21 @@ func TestGetFunction(t *testing.T) {
 	})
 }
 
-func TestGetFunctions(t *testing.T) {
+func TestListFunctions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	router, _, functions, _, _ := setup(ctrl)
 
-	t.Run("functions returned", func(t *testing.T) {
+	t.Run("list returned", func(t *testing.T) {
 		returnedList := function.Functions{{
 			ID:           function.ID("func1"),
 			Space:        "default",
 			ProviderType: httpprovider.Type,
 			Provider:     &httpprovider.HTTP{},
 		}}
-		functions.EXPECT().ListFunctions("default").Return(returnedList, nil)
+		functions.EXPECT().ListFunctions("default", metadata.Filter{Key: "key1", Value: "val1"}).Return(returnedList, nil)
 
-		resp := request(router, http.MethodGet, "/v1/spaces/default/functions", nil)
+		resp := request(router, http.MethodGet, "/v1/spaces/default/functions?metadata.key1=val1", nil)
 
 		fns := &httpapi.FunctionsResponse{}
 		json.Unmarshal(resp.Body.Bytes(), fns)
@@ -683,7 +684,7 @@ func TestGetCORS(t *testing.T) {
 	})
 }
 
-func TestGetCORSes(t *testing.T) {
+func TestListCORS(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	router, _, _, _, corses := setup(ctrl)
@@ -693,9 +694,9 @@ func TestGetCORSes(t *testing.T) {
 			Space: "default",
 			ID:    cors.ID("GET%2Fhello"),
 		}}
-		corses.EXPECT().ListCORS("default").Return(returnedList, nil)
+		corses.EXPECT().ListCORS("default", metadata.Filter{Key: "key1", Value: "val1"}).Return(returnedList, nil)
 
-		resp := request(router, http.MethodGet, "/v1/spaces/default/cors", nil)
+		resp := request(router, http.MethodGet, "/v1/spaces/default/cors?metadata.key1=val1", nil)
 
 		configs := &httpapi.CORSResponse{}
 		json.Unmarshal(resp.Body.Bytes(), configs)

--- a/libkv/cors.go
+++ b/libkv/cors.go
@@ -10,6 +10,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/serverless/event-gateway/metadata"
 	"github.com/serverless/event-gateway/subscription/cors"
 	"github.com/serverless/libkv/store"
 )
@@ -71,7 +72,7 @@ func (service Service) GetCORS(space string, id cors.ID) (*cors.CORS, error) {
 }
 
 // ListCORS returns an array of all CORS configuration in the space.
-func (service Service) ListCORS(space string) (cors.CORSes, error) {
+func (service Service) ListCORS(space string, filters ...metadata.Filter) (cors.CORSes, error) {
 	configs := []*cors.CORS{}
 
 	kvs, err := service.CORSStore.List(spacePath(space), &store.ReadOptions{Consistent: true})
@@ -87,6 +88,9 @@ func (service Service) ListCORS(space string) (cors.CORSes, error) {
 			return nil, err
 		}
 
+		if !config.Metadata.Check(filters...) {
+			continue
+		}
 		configs = append(configs, config)
 	}
 

--- a/libkv/eventtype.go
+++ b/libkv/eventtype.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/serverless/event-gateway/event"
+	"github.com/serverless/event-gateway/metadata"
 	"github.com/serverless/libkv/store"
 )
 
@@ -75,7 +76,7 @@ func (service Service) GetEventType(space string, name event.TypeName) (*event.T
 }
 
 // ListEventTypes returns an array of all event types in the space.
-func (service Service) ListEventTypes(space string) (event.Types, error) {
+func (service Service) ListEventTypes(space string, filters ...metadata.Filter) (event.Types, error) {
 	types := []*event.Type{}
 
 	kvs, err := service.EventTypeStore.List(spacePath(space), &store.ReadOptions{Consistent: true})
@@ -91,6 +92,9 @@ func (service Service) ListEventTypes(space string) (event.Types, error) {
 			return nil, err
 		}
 
+		if !eventType.Metadata.Check(filters...) {
+			continue
+		}
 		types = append(types, eventType)
 	}
 

--- a/libkv/function.go
+++ b/libkv/function.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/serverless/event-gateway/function"
+	"github.com/serverless/event-gateway/metadata"
 	"github.com/serverless/libkv/store"
 )
 
@@ -95,7 +96,7 @@ func (service Service) GetFunction(space string, id function.ID) (*function.Func
 }
 
 // ListFunctions returns an array of all functions in the space.
-func (service Service) ListFunctions(space string) (function.Functions, error) {
+func (service Service) ListFunctions(space string, filters ...metadata.Filter) (function.Functions, error) {
 	fns := []*function.Function{}
 
 	kvs, err := service.FunctionStore.List(spacePath(space), &store.ReadOptions{Consistent: true})
@@ -111,6 +112,9 @@ func (service Service) ListFunctions(space string) (function.Functions, error) {
 			return nil, err
 		}
 
+		if !fn.Metadata.Check(filters...) {
+			continue
+		}
 		fns = append(fns, fn)
 	}
 

--- a/libkv/function_test.go
+++ b/libkv/function_test.go
@@ -151,7 +151,7 @@ func TestGetFunction(t *testing.T) {
 	})
 }
 
-func TestGetFunctions(t *testing.T) {
+func TestListFunctions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 

--- a/libkv/subscription.go
+++ b/libkv/subscription.go
@@ -13,6 +13,7 @@ import (
 	"github.com/serverless/event-gateway/function"
 	"github.com/serverless/event-gateway/internal/pathtree"
 	istrings "github.com/serverless/event-gateway/internal/strings"
+	"github.com/serverless/event-gateway/metadata"
 	"github.com/serverless/event-gateway/subscription"
 	"github.com/serverless/libkv/store"
 	"go.uber.org/zap"
@@ -116,7 +117,7 @@ func (service Service) DeleteSubscription(space string, id subscription.ID) erro
 }
 
 // ListSubscriptions returns array of all Subscription.
-func (service Service) ListSubscriptions(space string) (subscription.Subscriptions, error) {
+func (service Service) ListSubscriptions(space string, filters ...metadata.Filter) (subscription.Subscriptions, error) {
 	subs := []*subscription.Subscription{}
 
 	kvs, err := service.SubscriptionStore.List(spacePath(space), &store.ReadOptions{Consistent: true})
@@ -132,6 +133,9 @@ func (service Service) ListSubscriptions(space string) (subscription.Subscriptio
 			return nil, err
 		}
 
+		if !s.Metadata.Check(filters...) {
+			continue
+		}
 		subs = append(subs, s)
 	}
 

--- a/metadata/filter.go
+++ b/metadata/filter.go
@@ -1,5 +1,6 @@
 package metadata
 
+// Filter is used in Services for filtering resources based on metadata value.
 type Filter struct {
 	Key   string
 	Value string

--- a/metadata/filter.go
+++ b/metadata/filter.go
@@ -1,0 +1,6 @@
+package metadata
+
+type Filter struct {
+	Key   string
+	Value string
+}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -1,0 +1,16 @@
+package metadata
+
+// Metadata stores additional information about resource.
+type Metadata map[string]string
+
+// Check checks if Metadata is compliant with all of the provided filters.
+func (m Metadata) Check(filters ...Filter) bool {
+	for _, filter := range filters {
+		value, ok := m[filter.Key]
+		if !ok || value != filter.Value {
+			return false
+		}
+	}
+
+	return true
+}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -1,0 +1,33 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/serverless/event-gateway/metadata"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheck(t *testing.T) {
+	t.Run("return false if metadata value doesn't match", func(t *testing.T) {
+		md := metadata.Metadata{"testkey1": "testvalue1"}
+
+		assert.False(t, md.Check(metadata.Filter{Key: "testkey1", Value: "nottestvalue1"}))
+	})
+
+	t.Run("return false if filter doesn't apply", func(t *testing.T) {
+		md := metadata.Metadata{"testkey1": "testvalue1"}
+
+		assert.False(t, md.Check(
+			metadata.Filter{Key: "testkey3", Value: "testvalue3"},
+		))
+	})
+
+	t.Run("return true if filter does applies", func(t *testing.T) {
+		md := metadata.Metadata{"testkey1": "testvalue1", "testkey2": "testvalue2"}
+
+		assert.True(t, md.Check(
+			metadata.Filter{Key: "testkey1", Value: "testvalue1"},
+			metadata.Filter{Key: "testkey2", Value: "testvalue2"},
+		))
+	})
+}

--- a/mock/cors.go
+++ b/mock/cors.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	metadata "github.com/serverless/event-gateway/metadata"
 	cors "github.com/serverless/event-gateway/subscription/cors"
 	reflect "reflect"
 )
@@ -72,16 +73,21 @@ func (mr *MockCORSServiceMockRecorder) GetCORS(arg0, arg1 interface{}) *gomock.C
 }
 
 // ListCORS mocks base method
-func (m *MockCORSService) ListCORS(arg0 string) (cors.CORSes, error) {
-	ret := m.ctrl.Call(m, "ListCORS", arg0)
+func (m *MockCORSService) ListCORS(arg0 string, arg1 ...metadata.Filter) (cors.CORSes, error) {
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListCORS", varargs...)
 	ret0, _ := ret[0].(cors.CORSes)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListCORS indicates an expected call of ListCORS
-func (mr *MockCORSServiceMockRecorder) ListCORS(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCORS", reflect.TypeOf((*MockCORSService)(nil).ListCORS), arg0)
+func (mr *MockCORSServiceMockRecorder) ListCORS(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCORS", reflect.TypeOf((*MockCORSService)(nil).ListCORS), varargs...)
 }
 
 // UpdateCORS mocks base method

--- a/mock/eventtype.go
+++ b/mock/eventtype.go
@@ -7,6 +7,7 @@ package mock
 import (
 	gomock "github.com/golang/mock/gomock"
 	event "github.com/serverless/event-gateway/event"
+	metadata "github.com/serverless/event-gateway/metadata"
 	reflect "reflect"
 )
 
@@ -72,16 +73,21 @@ func (mr *MockEventTypeServiceMockRecorder) GetEventType(arg0, arg1 interface{})
 }
 
 // ListEventTypes mocks base method
-func (m *MockEventTypeService) ListEventTypes(arg0 string) (event.Types, error) {
-	ret := m.ctrl.Call(m, "ListEventTypes", arg0)
+func (m *MockEventTypeService) ListEventTypes(arg0 string, arg1 ...metadata.Filter) (event.Types, error) {
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListEventTypes", varargs...)
 	ret0, _ := ret[0].(event.Types)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListEventTypes indicates an expected call of ListEventTypes
-func (mr *MockEventTypeServiceMockRecorder) ListEventTypes(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEventTypes", reflect.TypeOf((*MockEventTypeService)(nil).ListEventTypes), arg0)
+func (mr *MockEventTypeServiceMockRecorder) ListEventTypes(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEventTypes", reflect.TypeOf((*MockEventTypeService)(nil).ListEventTypes), varargs...)
 }
 
 // UpdateEventType mocks base method

--- a/mock/function.go
+++ b/mock/function.go
@@ -7,6 +7,7 @@ package mock
 import (
 	gomock "github.com/golang/mock/gomock"
 	function "github.com/serverless/event-gateway/function"
+	metadata "github.com/serverless/event-gateway/metadata"
 	reflect "reflect"
 )
 
@@ -72,16 +73,21 @@ func (mr *MockFunctionServiceMockRecorder) GetFunction(arg0, arg1 interface{}) *
 }
 
 // ListFunctions mocks base method
-func (m *MockFunctionService) ListFunctions(arg0 string) (function.Functions, error) {
-	ret := m.ctrl.Call(m, "ListFunctions", arg0)
+func (m *MockFunctionService) ListFunctions(arg0 string, arg1 ...metadata.Filter) (function.Functions, error) {
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListFunctions", varargs...)
 	ret0, _ := ret[0].(function.Functions)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListFunctions indicates an expected call of ListFunctions
-func (mr *MockFunctionServiceMockRecorder) ListFunctions(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFunctions", reflect.TypeOf((*MockFunctionService)(nil).ListFunctions), arg0)
+func (mr *MockFunctionServiceMockRecorder) ListFunctions(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFunctions", reflect.TypeOf((*MockFunctionService)(nil).ListFunctions), varargs...)
 }
 
 // UpdateFunction mocks base method

--- a/mock/subscription.go
+++ b/mock/subscription.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	metadata "github.com/serverless/event-gateway/metadata"
 	subscription "github.com/serverless/event-gateway/subscription"
 	reflect "reflect"
 )
@@ -72,16 +73,21 @@ func (mr *MockSubscriptionServiceMockRecorder) GetSubscription(arg0, arg1 interf
 }
 
 // ListSubscriptions mocks base method
-func (m *MockSubscriptionService) ListSubscriptions(arg0 string) (subscription.Subscriptions, error) {
-	ret := m.ctrl.Call(m, "ListSubscriptions", arg0)
+func (m *MockSubscriptionService) ListSubscriptions(arg0 string, arg1 ...metadata.Filter) (subscription.Subscriptions, error) {
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListSubscriptions", varargs...)
 	ret0, _ := ret[0].(subscription.Subscriptions)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListSubscriptions indicates an expected call of ListSubscriptions
-func (mr *MockSubscriptionServiceMockRecorder) ListSubscriptions(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubscriptions", reflect.TypeOf((*MockSubscriptionService)(nil).ListSubscriptions), arg0)
+func (mr *MockSubscriptionServiceMockRecorder) ListSubscriptions(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubscriptions", reflect.TypeOf((*MockSubscriptionService)(nil).ListSubscriptions), varargs...)
 }
 
 // UpdateSubscription mocks base method

--- a/subscription/cors/cors.go
+++ b/subscription/cors/cors.go
@@ -18,6 +18,8 @@ type CORS struct {
 	AllowedMethods   []string `json:"allowedMethods" validate:"min=1"`
 	AllowedHeaders   []string `json:"allowedHeaders" validate:"min=1"`
 	AllowCredentials bool     `json:"allowCredentials"`
+
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 // CORSes is an array of CORS configurations.

--- a/subscription/cors/cors.go
+++ b/subscription/cors/cors.go
@@ -20,7 +20,7 @@ type CORS struct {
 	AllowedHeaders   []string `json:"allowedHeaders" validate:"min=1"`
 	AllowCredentials bool     `json:"allowCredentials"`
 
-	Metadata *metadata.Metadata `json:"metadata,omitempty"`
+	Metadata metadata.Metadata `json:"metadata,omitempty"`
 }
 
 // CORSes is an array of CORS configurations.

--- a/subscription/cors/cors.go
+++ b/subscription/cors/cors.go
@@ -2,6 +2,7 @@ package cors
 
 import (
 	"github.com/serverless/event-gateway/internal/zap"
+	"github.com/serverless/event-gateway/metadata"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -19,7 +20,7 @@ type CORS struct {
 	AllowedHeaders   []string `json:"allowedHeaders" validate:"min=1"`
 	AllowCredentials bool     `json:"allowCredentials"`
 
-	Metadata map[string]string `json:"metadata,omitempty"`
+	Metadata *metadata.Metadata `json:"metadata,omitempty"`
 }
 
 // CORSes is an array of CORS configurations.

--- a/subscription/cors/service.go
+++ b/subscription/cors/service.go
@@ -1,9 +1,11 @@
 package cors
 
+import "github.com/serverless/event-gateway/metadata"
+
 // Service represents service for managing CORS configuration.
 type Service interface {
 	GetCORS(space string, id ID) (*CORS, error)
-	ListCORS(space string) (CORSes, error)
+	ListCORS(space string, filters ...metadata.Filter) (CORSes, error)
 	CreateCORS(c *CORS) (*CORS, error)
 	UpdateCORS(c *CORS) (*CORS, error)
 	DeleteCORS(space string, id ID) error

--- a/subscription/service.go
+++ b/subscription/service.go
@@ -1,9 +1,11 @@
 package subscription
 
+import "github.com/serverless/event-gateway/metadata"
+
 // Service represents service for managing subscriptions.
 type Service interface {
 	GetSubscription(space string, id ID) (*Subscription, error)
-	ListSubscriptions(space string) (Subscriptions, error)
+	ListSubscriptions(space string, filters ...metadata.Filter) (Subscriptions, error)
 	CreateSubscription(s *Subscription) (*Subscription, error)
 	UpdateSubscription(id ID, s *Subscription) (*Subscription, error)
 	DeleteSubscription(space string, id ID) error

--- a/subscription/subscription.go
+++ b/subscription/subscription.go
@@ -3,6 +3,7 @@ package subscription
 import (
 	"github.com/serverless/event-gateway/event"
 	"github.com/serverless/event-gateway/function"
+	"github.com/serverless/event-gateway/metadata"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -16,7 +17,7 @@ type Subscription struct {
 	Path       string         `json:"path" validate:"required,urlPath"`
 	Method     string         `json:"method" validate:"required,eq=GET|eq=POST|eq=DELETE|eq=PUT|eq=PATCH|eq=HEAD|eq=OPTIONS"`
 
-	Metadata map[string]string `json:"metadata,omitempty"`
+	Metadata *metadata.Metadata `json:"metadata,omitempty"`
 }
 
 // ID uniquely identifies a subscription.

--- a/subscription/subscription.go
+++ b/subscription/subscription.go
@@ -15,6 +15,8 @@ type Subscription struct {
 	FunctionID function.ID    `json:"functionId" validate:"required"`
 	Path       string         `json:"path" validate:"required,urlPath"`
 	Method     string         `json:"method" validate:"required,eq=GET|eq=POST|eq=DELETE|eq=PUT|eq=PATCH|eq=HEAD|eq=OPTIONS"`
+
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 // ID uniquely identifies a subscription.

--- a/subscription/subscription.go
+++ b/subscription/subscription.go
@@ -17,7 +17,7 @@ type Subscription struct {
 	Path       string         `json:"path" validate:"required,urlPath"`
 	Method     string         `json:"method" validate:"required,eq=GET|eq=POST|eq=DELETE|eq=PUT|eq=PATCH|eq=HEAD|eq=OPTIONS"`
 
-	Metadata *metadata.Metadata `json:"metadata,omitempty"`
+	Metadata metadata.Metadata `json:"metadata,omitempty"`
 }
 
 // ID uniquely identifies a subscription.


### PR DESCRIPTION
## What did you implement:

When creating or updating a Function/Subscription/Event Types/CORS config, you may also provide optional metadata that describes additional information about your function. 

`metadata` fields is `map[string]string` field that allows storing arbitrary key/value pairs and the filtering resources based on those values.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES