### PR TITLE
Fix creating sync subscription for the same method and path (#476)

### DIFF
--- a/examples/users-service/README.md
+++ b/examples/users-service/README.md
@@ -117,7 +117,7 @@ Now let's give it a try! Using `curl` or in your browser, navigate to the `getUs
 ```bash
 $ curl -X GET https://tenant-myapp.slsgateway.com/users/15 | jq "."
 {
-  "id": "10",
+  "id": "15",
   "name": "Ariel Dach",
   "email": "Aubree22@gmail.com"
 }

--- a/libkv/subscription.go
+++ b/libkv/subscription.go
@@ -265,7 +265,13 @@ func isPathInConflict(existing, new string) bool {
 }
 
 func newSubscriptionID(sub *subscription.Subscription) subscription.ID {
-	raw := string(sub.Type) + "," + string(sub.EventType) + "," + string(sub.FunctionID) + "," + url.PathEscape(sub.Path) + "," + sub.Method
+	var raw string
+	if sub.Type == subscription.TypeAsync {
+		raw = string(sub.Type) + "," + string(sub.EventType) + "," + string(sub.FunctionID) + "," + url.PathEscape(sub.Path) + "," + sub.Method
+	} else {
+		raw = string(sub.Type) + "," + string(sub.EventType) + "," + url.PathEscape(sub.Path) + "," + sub.Method
+	}
+
 	return subscription.ID(base64.RawURLEncoding.EncodeToString([]byte(raw)))
 }
 

--- a/libkv/subscription_test.go
+++ b/libkv/subscription_test.go
@@ -28,9 +28,9 @@ func TestCreateSubscription(t *testing.T) {
 		Type: subscription.TypeAsync, EventType: "user.created", FunctionID: "func", Path: "/", Method: "GET"}
 	asyncEventPayload := []byte(`{"space":"default","name":"user.created"}`)
 
-	syncKey := "default/c3luYyxodHRwLnJlcXVlc3QsZnVuYywlMkYsUE9TVA"
+	syncKey := "default/c3luYyxodHRwLnJlcXVlc3QsJTJGLFBPU1Q"
 	syncValue := []byte(
-		`{"space":"default","subscriptionId":"c3luYyxodHRwLnJlcXVlc3QsZnVuYywlMkYsUE9TVA",` +
+		`{"space":"default","subscriptionId":"c3luYyxodHRwLnJlcXVlc3QsJTJGLFBPU1Q",` +
 			`"type":"sync","eventType":"http.request","functionId":"func","path":"/","method":"POST"}`)
 	syncSub := &subscription.Subscription{
 		Type: subscription.TypeSync, EventType: "http.request", FunctionID: "func", Path: "/", Method: "POST"}


### PR DESCRIPTION
This PR fixes creating multiple sync subscription for the same path and method. 

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES