### PR TITLE
Implement missing interface methods in plugin logger

### DIFF
--- a/plugin/logger.go
+++ b/plugin/logger.go
@@ -71,6 +71,11 @@ func (l Hclog2ZapLogger) ResetNamed(name string) hclog.Logger {
 	return Hclog2ZapLogger{}
 }
 
+// SetLevel implementation.
+func (l Hclog2ZapLogger) SetLevel(level hclog.Level) {
+	// no need to implement that as go-plugin doesn't use this method.
+}
+
 // StandardLogger implementation.
 func (l Hclog2ZapLogger) StandardLogger(opts *hclog.StandardLoggerOptions) *log.Logger {
 	// no need to implement that as go-plugin doesn't use this method.


### PR DESCRIPTION
hclog interface changed two days ago causing EG build to fail.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO