### PR TITLE
Add Kubernetes Helm chart (#448)

### DIFF
--- a/contrib/helm/README.md
+++ b/contrib/helm/README.md
@@ -1,0 +1,49 @@
+# Event Gateway Helm chart
+
+This chart deploys the Event Gateway with etcd onto a Kubernetes cluster.
+
+## Installation
+
+Make sure you have helm installed on you machine and run `helm init` on your K8s cluster.
+
+From the `event-gateway/contrib/helm` folder:
+
+First, install etcd operator:
+```
+helm install stable/etcd-operator --name ego
+```
+
+Then, install the Event Gateway:
+```
+helm install event-gateway --name eg
+```
+
+Note: to deploy the stack to a namespace other than the default, add `--namespace` option to both `helm install` commands.
+
+To get the Event Gateway load balancer IP:
+```
+kubectl get svc
+```
+
+To delete the Event Gatway and etcd:
+```
+helm delete eg
+helm delete ego
+```
+
+## Configuration
+
+| Parameter                   | Description                                  | Default                    |
+|-----------------------------|----------------------------------------------|----------------------------|
+| `images.repository`         | Event Gateway image                          | `serverless/event-gateway` |
+| `images.tag`                | Event Gateway image tag                      | `0.9.0`                    |
+| `replicaCount`              | Number of containers                         | `3`                        |
+| `service.type`              | Type of Kubernetes service                   | `LoadBalancer`             |
+| `service.config.port`       | Config API port number                       | `4001`                     |
+| `service.events.port`       | Events API port number                       | `4000`                     |
+| `resources.limits.cpu`      | CPU resource limits                          | `200m`                     |
+| `resources.limits.memory`   | Memory resource limits                       | `256Mi`                    |
+| `resources.requests.cpu`    | CPU resource requests                        | `200m`                     |
+| `resources.requests.memory` | Memory resource requests                     | `256Mi`                    |
+| `command`                   | Options to pass to `event-gateway` command   | `[-db-hosts=eg-etcd-cluster-client:2379, -log-level=debug]`|
+| `etcd_cluster_name`         | Name of the etcd cluster. Must be passed to the `-db-host` option as `<etcd-cluster-name>-client`  | `eg-etcd-cluster`|

--- a/contrib/helm/event-gateway/.helmignore
+++ b/contrib/helm/event-gateway/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/contrib/helm/event-gateway/Chart.yaml
+++ b/contrib/helm/event-gateway/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: https://github.com/serverless/event-gateway
+name: event-gateway
+version: 0.1.0

--- a/contrib/helm/event-gateway/templates/_helpers.tpl
+++ b/contrib/helm/event-gateway/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "event-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "event-gateway.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "event-gateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/contrib/helm/event-gateway/templates/etcd-cluster.yaml
+++ b/contrib/helm/event-gateway/templates/etcd-cluster.yaml
@@ -1,0 +1,7 @@
+apiVersion: "etcd.database.coreos.com/v1beta2"
+kind: "EtcdCluster"
+metadata:
+  name: {{ .Values.etcd_cluster_name }}
+spec:
+  size: 3
+  version: "3.2.13"

--- a/contrib/helm/event-gateway/templates/event-gateway.yaml
+++ b/contrib/helm/event-gateway/templates/event-gateway.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "event-gateway.fullname" . }}
+  labels:
+    app: {{ template "event-gateway.fullname" . }}
+    chart: {{ template "event-gateway.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "event-gateway.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "event-gateway.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            {{- range .Values.command }}
+            - {{ . }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /v1/status
+              port: {{ .Values.service.config.port }}
+          readinessProbe:
+            httpGet:
+              path: /v1/status
+              port: {{ .Values.service.config.port }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "event-gateway.fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: config
+    port: {{ .Values.service.config.port }}
+  - name: events
+    port: {{ .Values.service.events.port }}
+  selector:
+    app: {{ template "event-gateway.name" . }}

--- a/contrib/helm/event-gateway/values.yaml
+++ b/contrib/helm/event-gateway/values.yaml
@@ -1,0 +1,20 @@
+image:
+  repository: serverless/event-gateway
+  tag: 0.9.0
+  pullPolicy: IfNotPresent
+replicaCount: 3
+service:
+  type: LoadBalancer
+  config:
+    port: 4001
+  events:
+    port: 4000
+resources:
+  limits:
+   cpu: 200m
+   memory: 256Mi
+  requests:
+   cpu: 200m
+   memory: 256Mi
+command: ["-db-hosts=eg-etcd-cluster-client:2379", "-log-level=debug"]
+etcd_cluster_name: eg-etcd-cluster


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/event-gateway/blob/master/CONTRIBUTING.md
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
1. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #448

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

This is a basic, non-prod setup, as it lacks some features, like RBAC for etcd and Event Gateway or TLS for etcd. 
More details regarding etcd installation https://github.com/coreos/etcd-operator/tree/master/doc/user.
I think the question is if we want to leave the initial implementation like this (just for playing around with EG on K8s), or it should be as much prod-ready as possible at the start.

Currently, there's only one external service (LoadBalancer), exposing both config and events ports. Probably a better options would be to have 2 services with ingress in front. The problem is that events api doesn't expose a health check endpoint.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.
-->

## Todos:

- [ ] Write tests
- [x] Write documentation
- [ ] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO