### PR TITLE
Consistent prefix for system events and metrics. Closes #425

### DIFF
--- a/docs/system-events-and-plugin-system.md
+++ b/docs/system-events-and-plugin-system.md
@@ -5,18 +5,18 @@
 System Events are special type of events emitted by the Event Gateway instance internally. They are emitted on each stage
 of event processing flow starting from receiving event to function invocation end. Those events are:
 
-* `gateway.event.received` - the event is emitted when an event was received by Events API. Data fields:
+* `eventgateway.event.received` - the event is emitted when an event was received by Events API. Data fields:
   * `event` - event payload
   * `path` - Events API path
   * `headers` - HTTP request headers
-* `gateway.function.invoking` - the event emitted before invoking a function. Data fields:
+* `eventgateway.function.invoking` - the event emitted before invoking a function. Data fields:
   * `event` - event payload
   * `functionId` - registered function ID
-* `gateway.function.invoked` - the event emitted after successful function invocation. Data fields:
+* `eventgateway.function.invoked` - the event emitted after successful function invocation. Data fields:
   * `event` - event payload
   * `functionId` - registered function ID
   * `result` - function response
-* `gateway.function.invocationFailed` - the event emitted after failed function invocation. Data fields:
+* `eventgateway.function.invocationFailed` - the event emitted after failed function invocation. Data fields:
   * `event` - event payload
   * `functionId` - registered function ID
   * `error` - invocation error

--- a/event/event.go
+++ b/event/event.go
@@ -116,7 +116,7 @@ func (e *Event) Validate() error {
 
 // IsSystem indicates if the event is a system event.
 func (e *Event) IsSystem() bool {
-	return strings.HasPrefix(string(e.EventType), "gateway.")
+	return strings.HasPrefix(string(e.EventType), "eventgateway.")
 }
 
 // MarshalLogObject is a part of zapcore.ObjectMarshaler interface

--- a/event/system.go
+++ b/event/system.go
@@ -5,7 +5,7 @@ import (
 )
 
 // SystemEventReceivedType is a system event emitted when the Event Gateway receives an event.
-const SystemEventReceivedType = TypeName("gateway.event.received")
+const SystemEventReceivedType = TypeName("eventgateway.event.received")
 
 // SystemEventReceivedData struct.
 type SystemEventReceivedData struct {
@@ -15,7 +15,7 @@ type SystemEventReceivedData struct {
 }
 
 // SystemFunctionInvokingType is a system event emitted before invoking a function.
-const SystemFunctionInvokingType = TypeName("gateway.function.invoking")
+const SystemFunctionInvokingType = TypeName("eventgateway.function.invoking")
 
 // SystemFunctionInvokingData struct.
 type SystemFunctionInvokingData struct {
@@ -25,7 +25,7 @@ type SystemFunctionInvokingData struct {
 }
 
 // SystemFunctionInvokedType is a system event emitted after successful function invocation.
-const SystemFunctionInvokedType = TypeName("gateway.function.invoked")
+const SystemFunctionInvokedType = TypeName("eventgateway.function.invoked")
 
 // SystemFunctionInvokedData struct.
 type SystemFunctionInvokedData struct {
@@ -36,7 +36,7 @@ type SystemFunctionInvokedData struct {
 }
 
 // SystemFunctionInvocationFailedType is a system event emitted after successful function invocation.
-const SystemFunctionInvocationFailedType = TypeName("gateway.function.invocationFailed")
+const SystemFunctionInvocationFailedType = TypeName("eventgateway.function.invocationFailed")
 
 // SystemFunctionInvocationFailedData struct.
 type SystemFunctionInvocationFailedData struct {

--- a/httpapi/metrics.go
+++ b/httpapi/metrics.go
@@ -18,7 +18,7 @@ func init() {
 
 var metricEventTypes = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
-		Namespace: "gateway",
+		Namespace: "eventgateway",
 		Subsystem: "eventtypes",
 		Name:      "total",
 		Help:      "Gauge of created event types count.",
@@ -28,7 +28,7 @@ var metricEventTypes = prometheus.NewGaugeVec(
 
 var metricFunctions = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
-		Namespace: "gateway",
+		Namespace: "eventgateway",
 		Subsystem: "functions",
 		Name:      "total",
 		Help:      "Gauge of registered functions count.",
@@ -38,7 +38,7 @@ var metricFunctions = prometheus.NewGaugeVec(
 
 var metricSubscriptions = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
-		Namespace: "gateway",
+		Namespace: "eventgateway",
 		Subsystem: "subscriptions",
 		Name:      "total",
 		Help:      "Gauge of created subscriptions count.",
@@ -48,7 +48,7 @@ var metricSubscriptions = prometheus.NewGaugeVec(
 
 var metricCORS = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
-		Namespace: "gateway",
+		Namespace: "eventgateway",
 		Subsystem: "cors",
 		Name:      "total",
 		Help:      "Gauge of created CORS configurations count.",
@@ -58,7 +58,7 @@ var metricCORS = prometheus.NewGaugeVec(
 
 var metricConfigRequests = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
-		Namespace: "gateway",
+		Namespace: "eventgateway",
 		Subsystem: "config",
 		Name:      "requests_total",
 		Help:      "Total of Config API requests.",
@@ -66,7 +66,7 @@ var metricConfigRequests = prometheus.NewCounterVec(
 
 var metricConfigRequestDuration = prometheus.NewHistogram(
 	prometheus.HistogramOpts{
-		Namespace: "gateway",
+		Namespace: "eventgateway",
 		Subsystem: "config",
 		Name:      "request_duration_seconds",
 		Help:      "Bucketed histogram of request duration of Config API requests",

--- a/router/metrics.go
+++ b/router/metrics.go
@@ -18,7 +18,7 @@ func init() {
 
 var metricEventsReceived = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
-		Namespace: "gateway",
+		Namespace: "eventgateway",
 		Subsystem: "events",
 		Name:      "received_total",
 		Help:      "Total of events received.",
@@ -26,7 +26,7 @@ var metricEventsReceived = prometheus.NewCounterVec(
 
 var metricEventsProcessed = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
-		Namespace: "gateway",
+		Namespace: "eventgateway",
 		Subsystem: "events",
 		Name:      "processed_total",
 		Help:      "Total of processed events.",
@@ -34,7 +34,7 @@ var metricEventsProcessed = prometheus.NewCounterVec(
 
 var metricEventsDropped = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
-		Namespace: "gateway",
+		Namespace: "eventgateway",
 		Subsystem: "events",
 		Name:      "dropped_total",
 		Help:      "Total of events dropped due to insufficient processing power.",
@@ -42,7 +42,7 @@ var metricEventsDropped = prometheus.NewCounterVec(
 
 var metricBacklog = prometheus.NewGauge(
 	prometheus.GaugeOpts{
-		Namespace: "gateway",
+		Namespace: "eventgateway",
 		Subsystem: "events",
 		Name:      "backlog",
 		Help:      "Gauge of asynchronous events count waiting to be processed.",
@@ -50,7 +50,7 @@ var metricBacklog = prometheus.NewGauge(
 
 var metricProcessingDuration = prometheus.NewHistogram(
 	prometheus.HistogramOpts{
-		Namespace: "gateway",
+		Namespace: "eventgateway",
 		Subsystem: "events",
 		Name:      "custom_processing_seconds",
 		Help: "Bucketed histogram of processing duration of an event. " +

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -80,7 +80,7 @@ func TestRouterServeHTTP(t *testing.T) {
 		router := setupTestRouter(target)
 
 		req, _ := http.NewRequest(http.MethodPost, "/", nil)
-		req.Header.Set("Event", "gateway.something")
+		req.Header.Set("Event", "eventgateway.something")
 		recorder := httptest.NewRecorder()
 		router.ServeHTTP(recorder, req)
 


### PR DESCRIPTION
## What did you implement:

Closes #425 

## How did you implement it:

All metrics and system events are not prefixed with `eventgateway` prefix. `gateway` was too ambiguous.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES