### PR TITLE
Fix path creation for hosted version

### DIFF
--- a/router/path.go
+++ b/router/path.go
@@ -10,6 +10,6 @@ func systemPathFromSpace(space string) string {
 	return basePath
 }
 
-func systemPathFromPath(path string) string {
+func systemPathFromURL(host, path string) string {
 	return basePath
 }

--- a/router/path_hosted.go
+++ b/router/path_hosted.go
@@ -14,19 +14,23 @@ func init() {
 }
 
 func extractPath(host, path string) string {
-	extracted := path
 	if hostedDomainPattern.Copy().MatchString(host) {
 		subdomain := strings.Split(host, ".")[0]
-		extracted = basePath + subdomain + path
+		return basePath + subdomain + path
 	}
-	return extracted
+	return path
 }
 
 func systemPathFromSpace(space string) string {
 	return basePath + space + "/"
 }
 
-// systemPathFromPath constructs path from path on which event was emitted. Helpful for "event.received" system event.
-func systemPathFromPath(path string) string {
-	return basePath + strings.Split(path, "/")[1] + "/"
+// systemPathFromURL constructs system event path based on hostname and path
+// on which the event was emitted. Helpful for "event.received" system event.
+func systemPathFromURL(host, path string) string {
+	if hostedDomainPattern.Copy().MatchString(host) {
+		segment := strings.Split(path, "/")[1]
+		return basePath + segment + "/"
+	}
+	return basePath
 }


### PR DESCRIPTION
This PR prevents from creating wrong path for system events in case of hosted version called via IP.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes
***Is it a breaking change?:*** NO