### PR TITLE
Ignore EventTime if it's not present

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,6 +20,12 @@
   version = "v1.3.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/bouk/monkey"
+  packages = ["."]
+  revision = "5df1f207ff77e025801505ae4d903133a0b4353f"
+
+[[projects]]
   name = "github.com/cockroachdb/cmux"
   packages = ["."]
   revision = "112f0506e7743d64a6eb8fedbcff13d9979bbf92"
@@ -263,6 +269,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "40303385e38e32716a606f65ba02c55615db5dbbf68100052f8265e835747293"
+  inputs-digest = "d6373538a2997e117949edecf1a8de3f004aa79782970ba9c3a859d2f36ab9c1"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/event/event.go
+++ b/event/event.go
@@ -34,7 +34,7 @@ type Event struct {
 	CloudEventsVersion string                 `json:"cloudEventsVersion" validate:"required"`
 	Source             string                 `json:"source" validate:"uri,required"`
 	EventID            string                 `json:"eventID" validate:"required"`
-	EventTime          time.Time              `json:"eventTime,omitempty"`
+	EventTime          *time.Time             `json:"eventTime,omitempty"`
 	SchemaURL          string                 `json:"schemaURL,omitempty"`
 	Extensions         zap.MapStringInterface `json:"extensions,omitempty"`
 	ContentType        string                 `json:"contentType,omitempty"`
@@ -43,12 +43,14 @@ type Event struct {
 
 // New return new instance of Event.
 func New(eventType TypeName, mimeType string, payload interface{}) *Event {
+	now := time.Now()
+
 	event := &Event{
 		EventType:          eventType,
 		CloudEventsVersion: CloudEventsVersion,
 		Source:             "https://serverless.com/event-gateway/#transformationVersion=" + TransformationVersion,
 		EventID:            uuid.NewV4().String(),
-		EventTime:          time.Now(),
+		EventTime:          &now,
 		ContentType:        mimeType,
 		Data:               payload,
 		Extensions: map[string]interface{}{
@@ -128,7 +130,9 @@ func (e Event) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("cloudEventsVersion", e.CloudEventsVersion)
 	enc.AddString("source", e.Source)
 	enc.AddString("eventID", e.EventID)
-	enc.AddString("eventTime", e.EventTime.String())
+	if e.EventTime != nil {
+		enc.AddString("eventTime", e.EventTime.String())
+	}
 	if e.SchemaURL != "" {
 		enc.AddString("schemaURL", e.SchemaURL)
 	}
@@ -180,8 +184,12 @@ func parseAsCloudEventBinary(headers http.Header, payload interface{}) (*Event, 
 		return nil, err
 	}
 
-	if val, err := time.Parse(time.RFC3339, headers.Get("CE-EventTime")); err == nil {
-		event.EventTime = val
+	if headers.Get("CE-EventTime") != "" {
+		if val, err := time.Parse(time.RFC3339, headers.Get("CE-EventTime")); err == nil {
+			event.EventTime = &val
+		} else {
+			return nil, err
+		}
 	}
 
 	if val := headers.Get("CE-SchemaURL"); len(val) > 0 {

--- a/event/event.go
+++ b/event/event.go
@@ -185,11 +185,11 @@ func parseAsCloudEventBinary(headers http.Header, payload interface{}) (*Event, 
 	}
 
 	if headers.Get("CE-EventTime") != "" {
-		if val, err := time.Parse(time.RFC3339, headers.Get("CE-EventTime")); err == nil {
-			event.EventTime = &val
-		} else {
+		val, err := time.Parse(time.RFC3339, headers.Get("CE-EventTime"))
+		if err != nil {
 			return nil, err
 		}
+		event.EventTime = &val
 	}
 
 	if val := headers.Get("CE-SchemaURL"); len(val) > 0 {


### PR DESCRIPTION
## What did you implement:

This PR fixes parsing CloudEvent EventTime field. If EventTime is not preset it will not fill it with default value (now EventTime is pointer to time.Time)

It also makes consistent parsing functions (parsing in binary mode should also return error if it's impossible to parse time).

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes
***Is it a breaking change?:*** NO