### PR TITLE
Helm: Pass etcd_cluster_name to command args. Allow service annotations

### DIFF
--- a/contrib/helm/README.md
+++ b/contrib/helm/README.md
@@ -39,6 +39,7 @@ helm delete ego
 | `images.tag`                | Event Gateway image tag                      | `0.9.0`                    |
 | `replicaCount`              | Number of containers                         | `3`                        |
 | `service.type`              | Type of Kubernetes service                   | `LoadBalancer`             |
+| `service.annotations`       | Custom annotations for the service           | `{}`                       |
 | `service.config.port`       | Config API port number                       | `4001`                     |
 | `service.events.port`       | Events API port number                       | `4000`                     |
 | `resources.limits.cpu`      | CPU resource limits                          | `200m`                     |
@@ -46,4 +47,16 @@ helm delete ego
 | `resources.requests.cpu`    | CPU resource requests                        | `200m`                     |
 | `resources.requests.memory` | Memory resource requests                     | `256Mi`                    |
 | `command`                   | Options to pass to `event-gateway` command   | `[-db-hosts=eg-etcd-cluster-client:2379, -log-level=debug]`|
-| `etcd_cluster_name`         | Name of the etcd cluster. Must be passed to the `-db-host` option as `<etcd-cluster-name>-client`  | `eg-etcd-cluster`|
+| `etcd_cluster_name`         | Name of the etcd cluster. Passed to the `-db-host` option as `<etcd-cluster-name>-client`  | `eg-etcd-cluster`|
+
+The service annotations can be used to set any annotations required by your platform, for example:
+
+```
+$ helm install . --name eg --set service.annotations="{service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0,foo: bar}" --debug --dry-run | grep "kind: Service" -A5
+kind: Service
+metadata:
+  name: eg-event-gateway
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+    foo: bar
+```

--- a/contrib/helm/README.md
+++ b/contrib/helm/README.md
@@ -39,7 +39,7 @@ helm delete ego
 | `images.tag`                | Event Gateway image tag                      | `0.9.0`                    |
 | `replicaCount`              | Number of containers                         | `3`                        |
 | `service.type`              | Type of Kubernetes service                   | `LoadBalancer`             |
-| `service.annotations`       | Custom annotations for the service           | `{}`                       |
+| `service.annotations`       | Custom annotations for the service           | `[]`                       |
 | `service.config.port`       | Config API port number                       | `4001`                     |
 | `service.events.port`       | Events API port number                       | `4000`                     |
 | `resources.limits.cpu`      | CPU resource limits                          | `200m`                     |
@@ -47,15 +47,25 @@ helm delete ego
 | `resources.requests.cpu`    | CPU resource requests                        | `200m`                     |
 | `resources.requests.memory` | Memory resource requests                     | `256Mi`                    |
 | `command`                   | Options to pass to `event-gateway` command   | `[-db-hosts=eg-etcd-cluster-client:2379, -log-level=debug]`|
-| `etcd_cluster_name`         | Name of the etcd cluster. Passed to the `-db-host` option as `<etcd-cluster-name>-client`  | `eg-etcd-cluster`|
+| `etcd_cluster_name`         | Name of the etcd cluster. Passed to the `-db-hosts` option as `<etcd-cluster-name>-client`  | `eg-etcd-cluster`|
 
-The service annotations can be used to set any annotations required by your platform, for example:
+The service annotations can be used to set any annotations required by your platform, for example, if
+you update your values.yml with:
 
 ```
-$ helm install . --name eg --set service.annotations="{service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0,foo: bar}" --debug --dry-run | grep "kind: Service" -A5
+-  annotations: []
++  annotations:
++    - "service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0"
++    - "foo: bar"
+```
+
+then the service will be annotated as shown:
+
+```
+$ helm install event-gateway --debug --dry-run | grep "kind: Service" -A5
 kind: Service
 metadata:
-  name: eg-event-gateway
+  name: rafting-umbrellabird-event-gateway
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
     foo: bar

--- a/contrib/helm/event-gateway/templates/event-gateway.yaml
+++ b/contrib/helm/event-gateway/templates/event-gateway.yaml
@@ -24,6 +24,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
+            - "-db-hosts={{ .Values.etcd_cluster_name }}-client:2379"
             {{- range .Values.command }}
             - {{ . }}
             {{- end }}
@@ -40,6 +41,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "event-gateway.fullname" . }}
+  annotations:
+    {{- range .Values.service.annotations }}
+    {{ . }}
+    {{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:

--- a/contrib/helm/event-gateway/templates/event-gateway.yaml
+++ b/contrib/helm/event-gateway/templates/event-gateway.yaml
@@ -24,7 +24,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "-db-hosts={{ .Values.etcd_cluster_name }}-client:2379"
+            - "-db-hosts={{ .Values.etcd_cluster_name }}-client:{{ .Values.etcd_cluster_port }}"
             {{- range .Values.command }}
             - {{ . }}
             {{- end }}

--- a/contrib/helm/event-gateway/values.yaml
+++ b/contrib/helm/event-gateway/values.yaml
@@ -9,7 +9,7 @@ service:
     port: 4001
   events:
     port: 4000
-  annotations:
+  annotations: []
 resources:
   limits:
    cpu: 200m
@@ -19,3 +19,4 @@ resources:
    memory: 256Mi
 command: ["-log-level=debug"]
 etcd_cluster_name: eg-etcd-cluster
+etcd_cluster_port: 2379

--- a/contrib/helm/event-gateway/values.yaml
+++ b/contrib/helm/event-gateway/values.yaml
@@ -9,6 +9,7 @@ service:
     port: 4001
   events:
     port: 4000
+  annotations:
 resources:
   limits:
    cpu: 200m
@@ -16,5 +17,5 @@ resources:
   requests:
    cpu: 200m
    memory: 256Mi
-command: ["-db-hosts=eg-etcd-cluster-client:2379", "-log-level=debug"]
+command: ["-log-level=debug"]
 etcd_cluster_name: eg-etcd-cluster


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/event-gateway/blob/master/CONTRIBUTING.md
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
1. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Small improvements to provided helm template after testing the existing one. I found it a little confusing (and unnecessary) to have to update the `command` option if you changed `etcd_cluster_name`. Also wasn't able to deploy in my k8s env without a specific service annotation, so added this option (but can remove if it's too noisy).

Relates to #448 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.
-->
Test the helm chart as per the README.md

## Todos:

- [ ] Write tests
- [X] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** Yes, perhaps @sebito91 based on the previous PR. Also cc @baniol in case he has other thoughts (and thanks for adding it in the first place!)
***Is it a breaking change?:*** No