### PR TITLE
Fix emitting invocationFailed system event for failed functions

### DIFF
--- a/router/metrics.go
+++ b/router/metrics.go
@@ -16,6 +16,8 @@ func init() {
 	prometheus.MustRegister(metricProcessingDuration)
 }
 
+const customEventType = "custom"
+
 var metricEventsReceived = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "eventgateway",


### PR DESCRIPTION
## What did you implement:

`eventgateway.function.invocationFailed` events were not emitted for every function failure. It happend only for some specific errors. This PR causes that those events (and in the same time metrics collection) are emitted in all situations.

## Todos:

- [ ] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO