### PR TITLE
Typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If you don't want to run the Event Gateway yourself, you can use the hosted vers
 
 ### via Docker
 
-There is a [official Docker image](https://hub.docker.com/r/serverless/event-gateway/).
+There is an [official Docker image](https://hub.docker.com/r/serverless/event-gateway/).
 
 ```bash
 docker run -p 4000:4000 -p 4001:4001 serverless/event-gateway --dev


### PR DESCRIPTION
## What did you implement:

Fixing a small typo in `README.md`: "a official" ➡️ "an official"

## How did you implement it:

Edited `README.md`

## How can we verify it:

https://dictionary.cambridge.org/us/grammar/british-grammar/determiners/a-an-and-the

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO